### PR TITLE
refactor: restructure MobileNav (#43)

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,380 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.14.48"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.14.48",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.14.48.tgz",
+      "integrity": "sha512-pb2ywByzn4i35WWJquEYyb8lDC/ph1PLXT+heucJN6Y9U/oeSw98JQV93IG7M6BUBks6MKD3DGDJdQfyD6x0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.14.48",
+        "effect": "4.0.0-beta.59",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.2.6",
+        "@opentui/keymap": ">=0.2.6",
+        "@opentui/solid": ">=0.2.6"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.14.48",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.48.tgz",
+      "integrity": "sha512-wKM86jCzV/ZApyWrdm3uP8XdWcS0LMbu3FV+OWz1ChiGGg1wiIWNGMJs5CY8/QX2/rUuZrd1Q1DqvdamZ0zLeg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.59",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.59.tgz",
+      "integrity": "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.6.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^6.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^1.11.9",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
+      "integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "@octokit/rest": "^22.0.1",
         "@openrouter/ai-sdk-provider": "^2.9.0",
         "@primer/octicons-react": "^19.25.0",
+        "@radix-ui/react-presence": "^1.1.5",
         "@react-email/components": "^1.0.12",
         "@shikijs/transformers": "4.0.2",
         "@t3-oss/env-nextjs": "^0.13.11",
@@ -39,6 +40,7 @@
         "embla-carousel-auto-scroll": "^8.6.0",
         "embla-carousel-react": "^8.6.0",
         "feed": "5.2.1",
+        "flexsearch": "^0.8.212",
         "frimousse": "^0.3.0",
         "fumadocs-core": "16.8.5",
         "fumadocs-docgen": "^3.0.10",
@@ -47,6 +49,7 @@
         "fumadocs-typescript": "5.2.6",
         "fumadocs-ui": "16.8.5",
         "hast": "1.0.0",
+        "hast-util-to-jsx-runtime": "^2.3.6",
         "jiti": "^2.6.1",
         "katex": "0.16.45",
         "lenis": "^1.3.23",
@@ -66,8 +69,10 @@
         "react-markdown": "^10.1.0",
         "rehype-katex": "7.0.1",
         "remark": "^15.0.1",
+        "remark-gfm": "^4.0.1",
         "remark-math": "6.0.0",
         "remark-mdx": "^3.1.1",
+        "remark-rehype": "^11.1.2",
         "resend": "^6.12.2",
         "schema-dts": "^2.0.0",
         "shadcn": "^4.6.0",
@@ -77,6 +82,7 @@
         "tailwind-scrollbar": "^4.0.2",
         "tempus": "1.0.0-dev.17",
         "tw-animate-css": "^1.4.0",
+        "unist-util-visit": "^5.1.0",
         "usehooks-ts": "^3.1.1",
         "web-haptics": "^0.0.6",
         "zod": "4.4.2",
@@ -1602,6 +1608,8 @@
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "flexsearch": ["flexsearch@0.8.212", "", {}, "sha512-wSyJr1GUWoOOIISRu+X2IXiOcVfg9qqBRyCPRUdLMIGJqPzMo+jMRlvE83t14v1j0dRMEaBbER/adQjp6Du2pw=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "embla-carousel-auto-scroll": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
     "feed": "5.2.1",
+    "flexsearch": "^0.8.212",
     "frimousse": "^0.3.0",
     "fumadocs-core": "16.8.5",
     "fumadocs-docgen": "^3.0.10",
@@ -101,7 +102,12 @@
     "tw-animate-css": "^1.4.0",
     "usehooks-ts": "^3.1.1",
     "web-haptics": "^0.0.6",
-    "zod": "4.4.2"
+    "zod": "4.4.2",
+    "@radix-ui/react-presence": "^1.1.5",
+    "remark-gfm": "^4.0.1",
+    "remark-rehype": "^11.1.2",
+    "hast-util-to-jsx-runtime": "^2.3.6",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.14",

--- a/src/app/(home)/blog/tags/page.tsx
+++ b/src/app/(home)/blog/tags/page.tsx
@@ -26,7 +26,7 @@ export default function Page() {
               whileInView={{ opacity: 1 }}
             >
               <TagCard
-                className='size-full items-center justify-start gap-2 rounded-none border-r bg-card/50 p-6 hover:bg-card/80'
+                className='size-full items-center justify-start gap-2 rounded-none border-r border-dashed bg-card/50 p-6 hover:bg-card/80'
                 displayCount
                 name={tag}
               />

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -11,24 +11,18 @@ import {
 import { env } from '@/env'
 import { systemPrompt } from '@/lib/ai/prompts/chat'
 import { provider } from '@/lib/ai/providers'
-import { contextDataSchema, type MyUIMessage } from './types'
+import type { MyUIMessage } from './types'
 import { getLLMsTxt } from './utils/llms'
 import { getPageContent } from './utils/tools/get-page-content'
 import { createSearchDocsTool } from './utils/tools/search-docs'
 import { showContactFormTool } from './utils/tools/show-contact-form'
 
-interface PageContext {
-  pathname?: string
-}
-
 export async function POST(request: Request) {
   try {
     const {
       messages,
-      pageContext,
     }: {
       messages: MyUIMessage[]
-      pageContext?: PageContext
     } = await request.json()
 
     const handleStreamError = (error: unknown) => {
@@ -55,19 +49,12 @@ export async function POST(request: Request) {
         const modelMessages = await convertToModelMessages<MyUIMessage>(
           messages,
           {
-            convertDataPart: (part) => {
-              if (part.type !== 'data-context') {
-                return
-              }
-
-              const context = contextDataSchema.safeParse(part.data).data?.text
-              if (!context) {
-                return
-              }
-
-              return {
-                type: 'text',
-                text: `\n\nSelected context (from page):\n"""\n${context}\n"""`,
+            convertDataPart(part) {
+              if (part.type === 'data-client') {
+                return {
+                  type: 'text',
+                  text: `[Client Context: ${JSON.stringify(part.data)}]`,
+                }
               }
             },
             ignoreIncompleteToolCalls: true,
@@ -80,7 +67,6 @@ export async function POST(request: Request) {
           model: provider.languageModel('chat-model'),
           system: systemPrompt({
             llms,
-            pageContext,
           }),
           providerOptions: {
             openai: {

--- a/src/app/api/chat/types.ts
+++ b/src/app/api/chat/types.ts
@@ -1,5 +1,7 @@
 import type { InferUITools, UIDataTypes, UIMessage } from 'ai'
+import type { DocumentData } from 'flexsearch'
 import { z } from 'zod'
+import type { PageEntry } from '@/app/actions/pages'
 import type { tools } from './utils/tools'
 
 export type ChatTools = InferUITools<typeof tools>
@@ -20,4 +22,12 @@ export type MyUIMessage = UIMessage<never, ChatDataTypes, ChatTools> & {
         title: string
       }
   >
+}
+
+export interface CustomDocument extends DocumentData {
+  content: string
+  description: string
+  tag: PageEntry['tag']
+  title: string
+  url: string
 }

--- a/src/app/api/chat/utils/tools/search-docs.ts
+++ b/src/app/api/chat/utils/tools/search-docs.ts
@@ -1,56 +1,78 @@
 import { tool, type UIMessageStreamWriter } from 'ai'
-import { initAdvancedSearch } from 'fumadocs-core/search/server'
+import { Document } from 'flexsearch'
 import { z } from 'zod'
-import { getPosts, getWorkPages } from '@/lib/source'
+import type { CustomDocument } from '@/app/api/chat/types'
+import { post as blogSource, workSource } from '@/lib/source'
 
-const pagesByUrl = new Map<
-  string,
-  {
-    title?: string
-    description?: string
-  }
->()
+const searchServer = createSearchServer()
 
-const server = initAdvancedSearch({
-  language: 'english',
-  indexes: () => {
-    const blogPages = getPosts()
-    const workPages = getWorkPages()
+async function createSearchServer() {
+  const search = new Document<CustomDocument>({
+    document: {
+      id: 'url',
+      index: ['title', 'description', 'content'],
+      store: true,
+      tag: ['tag'],
+    },
+  })
 
-    for (const page of blogPages) {
-      pagesByUrl.set(page.url, {
-        title: page.data.title,
-        description: page.data.description,
-      })
-    }
+  const blog = await chunkedAll(
+    blogSource.getPages().map(async (page) => {
+      if (!('getText' in page.data)) {
+        return null
+      }
 
-    for (const page of workPages) {
-      pagesByUrl.set(page.url, {
-        title: page.data.title,
-        description: page.data.description,
-      })
-    }
-
-    return [
-      ...blogPages.map((page) => ({
-        id: page.url,
-        title: page.data.title ?? 'Untitled',
-        description: page.data.description,
-        structuredData: page.data.structuredData,
-        url: page.url,
+      return {
+        content: await page.data.getText('processed'),
+        description: page.data.description ?? '',
         tag: 'blog',
-      })),
-      ...workPages.map((page) => ({
-        id: page.url,
         title: page.data.title ?? 'Untitled',
-        description: page.data.description,
-        structuredData: page.data.structuredData,
         url: page.url,
+      } as CustomDocument
+    })
+  )
+
+  const work = await chunkedAll(
+    workSource.getPages().map(async (page) => {
+      if (!('getText' in page.data)) {
+        return null
+      }
+
+      return {
+        content: await page.data.getText('processed'),
+        description: page.data.description ?? '',
         tag: 'projects',
-      })),
-    ]
-  },
-})
+        title: page.data.title ?? 'Untitled',
+        url: page.url,
+      } as CustomDocument
+    })
+  )
+
+  for (const post of blog) {
+    if (post) {
+      search.add(post)
+    }
+  }
+
+  for (const page of work) {
+    if (page) {
+      search.add(page)
+    }
+  }
+
+  return search
+}
+
+async function chunkedAll<O>(promises: Promise<O>[]): Promise<O[]> {
+  const size = 50
+  const out: O[] = []
+
+  for (let i = 0; i < promises.length; i += size) {
+    out.push(...(await Promise.all(promises.slice(i, i + size))))
+  }
+
+  return out
+}
 
 const Tag = z.union([
   z.literal('all'),
@@ -73,62 +95,33 @@ export const createSearchDocsTool = (writer: UIMessageStreamWriter) =>
         .number()
         .int()
         .min(1)
-        .max(50)
+        .max(100)
         .default(10)
         .describe(
-          'Maximum number of results to return (default: 10, max: 50).'
+          'Maximum number of results to return (default: 10, max: 100).'
         ),
     }),
-    execute: async ({ query, tag: tagParam, locale, limit }) => {
+    execute: async ({ query, tag: tagParam, limit }) => {
       const tag = tagParam === 'all' ? undefined : tagParam
-      const results = await server.search(query, {
-        tag,
-        locale,
+      const search = await searchServer
+      const raw = await search.searchAsync({
+        query,
+        limit,
+        merge: true,
+        enrich: true,
+        tag: tag ? ({ tag } as Record<string, string>) : undefined,
       })
+      const results = raw as Array<{ doc: CustomDocument }>
 
-      const seen = new Set<string>()
-      const deduped = results.filter((result) => {
-        if (!result.url || seen.has(result.url)) {
-          return false
-        }
-        seen.add(result.url)
-        return true
-      })
-
-      const trimmed = deduped.slice(0, limit).map((doc) => {
-        const pageInfo = pagesByUrl.get(doc.url)
-
-        return {
-          ...doc,
-          pageTitle: pageInfo?.title,
-          pageDescription: pageInfo?.description,
-        }
-      })
-
-      trimmed.forEach((doc, index) => {
-        const title = doc.pageTitle ?? doc.url
+      for (const [index, result] of results.entries()) {
         writer.write({
           type: 'source-url',
-          sourceId: `search-doc-${index}-${doc.url}`,
-          url: doc.url,
-          title,
+          sourceId: `search-doc-${index}-${result.doc.url}`,
+          title: result.doc.title,
+          url: result.doc.url,
         })
-      })
-
-      if (trimmed.length === 0) {
-        return `No content found for query "${query}".`
       }
 
-      const summary = trimmed
-        .map((doc, index) => {
-          const title = doc.pageTitle ?? doc.url
-          const description = doc.pageDescription
-            ? ` — ${doc.pageDescription}`
-            : ''
-          return `${index + 1}. ${title} (${doc.url})${description}`
-        })
-        .join('\n')
-
-      return `Found ${trimmed.length} pages for "${query}":\n${summary}`
+      return results
     },
   })

--- a/src/components/ai/chat.tsx
+++ b/src/components/ai/chat.tsx
@@ -6,7 +6,6 @@ import { Presence } from '@radix-ui/react-presence'
 import { useSound } from '@web-kits/audio/react'
 import { DefaultChatTransport, getStaticToolName, isStaticToolUIPart } from 'ai'
 import { buttonVariants } from 'fumadocs-ui/components/ui/button'
-import { usePathname } from 'next/navigation'
 import {
   type ComponentProps,
   createContext,
@@ -77,7 +76,6 @@ export function useChatContext() {
 
 export function AISearch({ children }: { children: ReactNode }) {
   const isMobile = useIsMobile()
-  const pathname = usePathname()
   const [open, setOpen] = useState(false)
   const [context, setContext] = useState<string | null>(null)
   const playError = useSound(errorSound)
@@ -97,15 +95,6 @@ export function AISearch({ children }: { children: ReactNode }) {
     },
     transport: new DefaultChatTransport({
       api: '/api/chat',
-      prepareSendMessagesRequest: ({ id, messages }) => ({
-        body: {
-          id,
-          messages,
-          pageContext: {
-            pathname,
-          },
-        },
-      }),
     }),
   })
 
@@ -264,6 +253,12 @@ function SearchAIInput(props: ComponentProps<'form'>) {
 
     await sendMessage({
       parts: [
+        {
+          type: 'data-client',
+          data: {
+            location: window.location.href,
+          },
+        },
         {
           type: 'text',
           text: messageText,

--- a/src/components/mdx/github-code.tsx
+++ b/src/components/mdx/github-code.tsx
@@ -22,7 +22,7 @@ interface GitHubCodeProps {
 
 function GitHubSourceLink({ sourceUrl }: { sourceUrl: string }) {
   return (
-    <div className='absolute top-[7px] right-9 z-10'>
+    <div className='absolute top-[7px] right-9 z-10 bg-(--shiki-light-bg) dark:bg-(--shiki-dark-bg)'>
       <a
         aria-label='View source on GitHub'
         className='inline-flex items-center justify-center rounded-md p-1 font-medium text-fd-muted-foreground text-sm transition-colors duration-100 hover:text-fd-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring disabled:pointer-events-none disabled:opacity-50 data-checked:text-fd-accent-foreground [&_svg]:size-4'

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -2,214 +2,49 @@
 
 import { Presence } from '@radix-ui/react-presence'
 import { useSearchContext } from 'fumadocs-ui/contexts/search'
-import Link from 'next/link'
-import { usePathname } from 'next/navigation'
 import { useState } from 'react'
 import { useAISearchContext } from '@/components/ai/chat'
-import { Icons } from '@/components/icons/icons'
-import { ThemeToggle } from '@/components/sections/header/theme-toggle'
-import { linkItems, socials } from '@/constants/navigation'
-import { isActive } from '@/lib/is-active'
-import { cn } from '@/lib/utils'
-
-const PRIMARY_LINKS = [
-  { href: '/', icon: <Icons.home className='size-4' />, label: 'Home' },
-  { href: '/about', icon: <Icons.user className='size-4' />, label: 'About' },
-  { href: '/work', icon: <Icons.work className='size-4' />, label: 'Work' },
-]
-
-function NavItem({
-  href,
-  icon,
-  label,
-  nested,
-}: {
-  href: string
-  icon: React.ReactNode
-  label: string
-  nested?: boolean
-}) {
-  const pathname = usePathname()
-  const active = isActive(href, pathname, nested)
-
-  return (
-    <Link
-      aria-current={active ? 'page' : undefined}
-      aria-label={label}
-      className={cn(
-        'flex size-8 items-center justify-center rounded-full transition-colors',
-        active
-          ? 'bg-primary/10 text-primary'
-          : 'text-muted-foreground hover:text-foreground'
-      )}
-      href={href}
-    >
-      {icon}
-    </Link>
-  )
-}
+import { FloatingPill } from '@/components/mobile-nav/floating-pill'
+import { MenuPanel } from '@/components/mobile-nav/menu-panel'
 
 export function MobileNav() {
   const [menuOpen, setMenuOpen] = useState(false)
   const { setOpenSearch } = useSearchContext()
   const { setOpen: setOpenAI } = useAISearchContext()
-  const pathname = usePathname()
 
-  const items = [
-    {
-      url: '/',
-      text: 'Home',
-      icon: <Icons.home />,
-      active: 'url' as const,
-    },
-    ...linkItems,
-  ].filter(
-    (item): item is typeof item & { url: string; text: string } =>
-      'url' in item && 'text' in item
-  )
-
-  // Chunk items into rows of 2 for divide-based borders
-  const rows: (typeof items)[] = []
-  for (let i = 0; i < items.length; i += 2) {
-    rows.push(items.slice(i, i + 2))
-  }
+  const closeMenu = () => setMenuOpen(false)
 
   return (
     <>
-      {/* Backdrop */}
       <Presence present={menuOpen}>
         <button
           aria-label='Close menu'
           className='fixed inset-0 z-[31] bg-background/50 data-[state=closed]:animate-fd-fade-out data-[state=open]:animate-fd-fade-in sm:hidden'
           data-state={menuOpen ? 'open' : 'closed'}
-          onClick={() => setMenuOpen(false)}
+          onClick={closeMenu}
           type='button'
         />
       </Presence>
 
-      {/* Menu panel */}
       <Presence present={menuOpen}>
-        <div
-          className={cn(
-            'fixed inset-x-4 bottom-20 z-[32] overflow-hidden rounded-xl border border-dashed bg-background sm:hidden',
-            menuOpen ? 'animate-fd-dialog-in' : 'animate-fd-dialog-out'
-          )}
-        >
-          <nav className='flex flex-col divide-y divide-dashed divide-border'>
-            {rows.map((row) => (
-              <div
-                className='grid grid-cols-2 divide-x divide-dashed divide-border'
-                key={row.map((item) => item.url).join('-')}
-              >
-                {row.map((item) => {
-                  const activeType =
-                    'active' in item ? (item.active ?? 'url') : 'url'
-                  const active =
-                    activeType !== 'none' &&
-                    isActive(item.url, pathname, activeType === 'nested-url')
-
-                  return (
-                    <Link
-                      aria-current={active ? 'page' : undefined}
-                      className={cn(
-                        'flex items-center gap-2 px-4 py-3 text-sm transition-colors hover:bg-muted [&_svg]:size-3.5',
-                        active
-                          ? 'font-medium text-primary'
-                          : 'text-muted-foreground'
-                      )}
-                      href={item.url}
-                      key={item.url}
-                      onClick={() => setMenuOpen(false)}
-                    >
-                      {'icon' in item ? item.icon : null}
-                      {item.text}
-                    </Link>
-                  )
-                })}
-              </div>
-            ))}
-          </nav>
-          <div className='flex items-center justify-between border-t border-dashed px-3 py-2'>
-            <div className='flex items-center'>
-              {socials.map((s) => (
-                <a
-                  aria-label={s.name}
-                  className='flex size-8 items-center justify-center text-muted-foreground transition-colors hover:text-foreground [&_svg]:size-3.5'
-                  href={s.url}
-                  key={s.name}
-                  rel='noopener noreferrer'
-                  target='_blank'
-                >
-                  {s.icon}
-                </a>
-              ))}
-            </div>
-            <div className='flex items-center gap-1'>
-              <button
-                aria-label='Ask AI'
-                className='flex size-8 items-center justify-center text-muted-foreground transition-colors hover:text-foreground [&_svg]:size-3.5'
-                onClick={() => {
-                  setMenuOpen(false)
-                  setOpenAI(true)
-                }}
-                type='button'
-              >
-                <Icons.aiChat />
-              </button>
-              <ThemeToggle />
-            </div>
-          </div>
-        </div>
+        <MenuPanel
+          menuOpen={menuOpen}
+          onAIChatOpen={() => {
+            closeMenu()
+            setOpenAI(true)
+          }}
+          onClose={closeMenu}
+        />
       </Presence>
 
-      {/* Floating pill */}
-      <div className='fixed inset-x-0 bottom-4 z-[32] flex justify-center sm:hidden'>
-        <div className='flex items-center gap-0.5 rounded-full border bg-background/80 px-1.5 py-1.5 shadow-lg backdrop-blur-md'>
-          <button
-            aria-label='Search'
-            className='flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground'
-            onClick={() => {
-              setMenuOpen(false)
-              setOpenSearch(true)
-            }}
-            type='button'
-          >
-            <Icons.search className='size-4' />
-          </button>
-
-          <div className='mx-1 h-4 w-px bg-border' />
-
-          {PRIMARY_LINKS.map((link) => (
-            <NavItem
-              href={link.href}
-              icon={link.icon}
-              key={link.href}
-              label={link.label}
-              nested={link.href !== '/'}
-            />
-          ))}
-
-          <div className='mx-1 h-4 w-px bg-border' />
-
-          <button
-            aria-label='Toggle menu'
-            className={cn(
-              'relative flex size-8 items-center justify-center rounded-full transition-colors',
-              menuOpen
-                ? 'bg-primary/10 text-primary'
-                : 'text-muted-foreground hover:text-foreground'
-            )}
-            onClick={() => setMenuOpen((v) => !v)}
-            type='button'
-          >
-            {menuOpen ? (
-              <Icons.close className='size-4' />
-            ) : (
-              <Icons.menu className='size-4' />
-            )}
-          </button>
-        </div>
-      </div>
+      <FloatingPill
+        menuOpen={menuOpen}
+        onMenuToggle={() => setMenuOpen((open) => !open)}
+        onSearchOpen={() => {
+          closeMenu()
+          setOpenSearch(true)
+        }}
+      />
     </>
   )
 }

--- a/src/components/mobile-nav/floating-pill.tsx
+++ b/src/components/mobile-nav/floating-pill.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { Icons } from '@/components/icons/icons'
+import { NavItem } from '@/components/mobile-nav/nav-item'
+import { cn } from '@/lib/utils'
+
+export function FloatingPill({
+  menuOpen,
+  onMenuToggle,
+  onSearchOpen,
+}: {
+  menuOpen: boolean
+  onMenuToggle: () => void
+  onSearchOpen: () => void
+}) {
+  const primaryLinks = [
+    { href: '/', icon: <Icons.home className='size-4' />, label: 'Home' },
+    {
+      href: '/about',
+      icon: <Icons.user className='size-4' />,
+      label: 'About',
+    },
+    { href: '/work', icon: <Icons.work className='size-4' />, label: 'Work' },
+  ]
+
+  return (
+    <div className='fixed inset-x-0 bottom-4 z-[32] flex justify-center sm:hidden'>
+      <div className='flex items-center gap-0.5 rounded-full border bg-background/80 px-1.5 py-1.5 shadow-lg backdrop-blur-md'>
+        <button
+          aria-label='Search'
+          className='flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground'
+          onClick={onSearchOpen}
+          type='button'
+        >
+          <Icons.search className='size-4' />
+        </button>
+
+        <div className='mx-1 h-4 w-px bg-border' />
+
+        {primaryLinks.map((link) => (
+          <NavItem
+            href={link.href}
+            icon={link.icon}
+            key={link.href}
+            label={link.label}
+            nested={link.href !== '/'}
+          />
+        ))}
+
+        <div className='mx-1 h-4 w-px bg-border' />
+
+        <button
+          aria-label='Toggle menu'
+          className={cn(
+            'relative flex size-8 items-center justify-center rounded-full transition-colors',
+            menuOpen
+              ? 'bg-primary/10 text-primary'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+          onClick={onMenuToggle}
+          type='button'
+        >
+          {menuOpen ? (
+            <Icons.close className='size-4' />
+          ) : (
+            <Icons.menu className='size-4' />
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/mobile-nav/menu-panel.tsx
+++ b/src/components/mobile-nav/menu-panel.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Icons } from '@/components/icons/icons'
+import { ThemeToggle } from '@/components/sections/header/theme-toggle'
+import { linkItems, socials } from '@/constants/navigation'
+import { isActive } from '@/lib/is-active'
+import { cn } from '@/lib/utils'
+
+export function MenuPanel({
+  menuOpen,
+  onAIChatOpen,
+  onClose,
+}: {
+  menuOpen: boolean
+  onAIChatOpen: () => void
+  onClose: () => void
+}) {
+  const pathname = usePathname()
+  const menuItems = [
+    {
+      url: '/',
+      text: 'Home',
+      icon: <Icons.home />,
+      active: 'url' as const,
+    },
+    ...linkItems,
+  ].filter(
+    (item): item is typeof item & { text: string; url: string } =>
+      'url' in item && 'text' in item
+  )
+  const menuRows = Array.from(
+    { length: Math.ceil(menuItems.length / 2) },
+    (_, index) => menuItems.slice(index * 2, index * 2 + 2)
+  )
+
+  return (
+    <div
+      className={cn(
+        'fixed inset-x-4 bottom-20 z-[32] overflow-hidden rounded-xl border border-dashed bg-background sm:hidden',
+        menuOpen ? 'animate-fd-dialog-in' : 'animate-fd-dialog-out'
+      )}
+    >
+      <nav className='flex flex-col divide-y divide-dashed divide-border'>
+        {menuRows.map((row) => (
+          <div
+            className='grid grid-cols-2 divide-x divide-dashed divide-border'
+            key={row.map((item) => item.url).join('-')}
+          >
+            {row.map((item) => {
+              const activeType =
+                'active' in item ? (item.active ?? 'url') : 'url'
+              const active =
+                activeType !== 'none' &&
+                isActive(item.url, pathname, activeType === 'nested-url')
+
+              return (
+                <Link
+                  aria-current={active ? 'page' : undefined}
+                  className={cn(
+                    'flex items-center gap-2 px-4 py-3 text-sm transition-colors hover:bg-muted [&_svg]:size-3.5',
+                    active
+                      ? 'font-medium text-primary'
+                      : 'text-muted-foreground'
+                  )}
+                  href={item.url}
+                  key={item.url}
+                  onClick={onClose}
+                >
+                  {'icon' in item ? item.icon : null}
+                  {item.text}
+                </Link>
+              )
+            })}
+          </div>
+        ))}
+      </nav>
+      <div className='flex items-center justify-between border-t border-dashed px-3 py-2'>
+        <div className='flex items-center'>
+          {socials.map((social) => (
+            <a
+              aria-label={social.name}
+              className='flex size-8 items-center justify-center text-muted-foreground transition-colors hover:text-foreground [&_svg]:size-3.5'
+              href={social.url}
+              key={social.name}
+              rel='noopener noreferrer'
+              target='_blank'
+            >
+              {social.icon}
+            </a>
+          ))}
+        </div>
+        <div className='flex items-center gap-1'>
+          <button
+            aria-label='Ask AI'
+            className='flex size-8 items-center justify-center text-muted-foreground transition-colors hover:text-foreground [&_svg]:size-3.5'
+            onClick={onAIChatOpen}
+            type='button'
+          >
+            <Icons.aiChat />
+          </button>
+          <ThemeToggle />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/mobile-nav/nav-item.tsx
+++ b/src/components/mobile-nav/nav-item.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { isActive } from '@/lib/is-active'
+import { cn } from '@/lib/utils'
+
+export function NavItem({
+  href,
+  icon,
+  label,
+  nested,
+}: {
+  href: string
+  icon: React.ReactNode
+  label: string
+  nested?: boolean
+}) {
+  const pathname = usePathname()
+  const active = isActive(href, pathname, nested)
+
+  return (
+    <Link
+      aria-current={active ? 'page' : undefined}
+      aria-label={label}
+      className={cn(
+        'flex size-8 items-center justify-center rounded-full transition-colors',
+        active
+          ? 'bg-primary/10 text-primary'
+          : 'text-muted-foreground hover:text-foreground'
+      )}
+      href={href}
+    >
+      {icon}
+    </Link>
+  )
+}

--- a/src/components/ui/empty.tsx
+++ b/src/components/ui/empty.tsx
@@ -1,0 +1,82 @@
+import { cn } from '@/lib/utils'
+
+function Empty({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg p-6 text-center',
+        className
+      )}
+      data-slot='empty'
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        'flex max-w-sm flex-col items-center gap-1.5 text-center',
+        className
+      )}
+      data-slot='empty-header'
+      {...props}
+    />
+  )
+}
+
+function EmptyMedia({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        'mb-1 flex size-10 shrink-0 items-center justify-center rounded-full border bg-background text-muted-foreground [&_svg]:size-5',
+        className
+      )}
+      data-slot='empty-media'
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn('font-medium text-sm', className)}
+      data-slot='empty-title'
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({
+  className,
+  ...props
+}: React.ComponentProps<'p'>) {
+  return (
+    <p
+      className={cn('text-muted-foreground text-sm', className)}
+      data-slot='empty-description'
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn('flex items-center justify-center gap-2', className)}
+      data-slot='empty-content'
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+}

--- a/src/lib/ai/prompts/chat/index.ts
+++ b/src/lib/ai/prompts/chat/index.ts
@@ -2,27 +2,15 @@ import { corePrompt } from './core'
 import { directivesPrompt } from './directives'
 import { examplesPrompt } from './examples'
 import { llmsPrompt } from './llms'
-import { pageContextPrompt } from './page-context'
 import { personalityPrompt } from './personality'
 import { toolsPrompt } from './tools'
 
-interface PageContext {
-  pathname?: string
-}
-
-export const systemPrompt = ({
-  llms,
-  pageContext,
-}: {
-  llms: string
-  pageContext?: PageContext
-}) =>
+export const systemPrompt = ({ llms }: { llms: string }) =>
   [
     corePrompt,
     personalityPrompt,
     directivesPrompt,
     toolsPrompt,
-    pageContextPrompt(pageContext),
     llmsPrompt(llms),
     examplesPrompt,
   ]


### PR DESCRIPTION
* refactor: restructure MobileNav

* refactor: migrate page location to data-client pattern and fix FlexSearch types

Switch page context from system prompt (stale closure bug) to Fumadocs-style data-client message parts. Fix FlexSearch searchAsync overload error and use native tag filtering instead of manual post-filter. Remove dead search.tsx file. Export search types from api/chat/types.

* refactor: update TagCard border style and add background color to GitHubSourceLink