### PR TITLE
fix(blog): place article actions before comments

### DIFF
--- a/src/app/(home)/blog/[slug]/page.tsx
+++ b/src/app/(home)/blog/[slug]/page.tsx
@@ -25,6 +25,31 @@ export default async function Page(props: {
   const { body: Mdx, toc, tags, lastModified } = page.data
 
   const lastUpdate = lastModified ? new Date(lastModified) : undefined
+  const pageActions = (
+    <>
+      <div>
+        <p className='mb-1 text-muted-foreground text-sm'>Written by</p>
+        <p className='font-medium'>{page.data.author ?? 'Unknown'}</p>
+      </div>
+      <div>
+        <p className='mb-1 text-muted-foreground text-sm'>Created At</p>
+        <p className='font-medium'>{new Date(page.data.date).toDateString()}</p>
+      </div>
+      {lastUpdate && (
+        <div>
+          <p className='mb-1 text-muted-foreground text-sm'>Updated At</p>
+          <p className='font-medium'>{lastUpdate.toDateString()}</p>
+        </div>
+      )}
+      <div className='flex flex-col gap-2'>
+        <LLMCopyButtonWithViewOptions
+          githubUrl={`https://github.com/${owner}/${repo}/blob/main/content/blog/${params.slug}.mdx`}
+          markdownUrl={`/blog.mdx/${params.slug}`}
+        />
+        <ShareMenu title={page.data.title ?? 'Untitled'} url={page.url} />
+      </div>
+    </>
+  )
 
   return (
     <>
@@ -32,33 +57,20 @@ export default async function Page(props: {
 
       <SectionBody>
         <article className='flex min-h-full flex-col lg:flex-row'>
-          <MdxContent comments slug={params.slug} toc={toc}>
+          <MdxContent
+            beforeComments={
+              <aside className='flex flex-col gap-4 border-border border-t border-dashed p-4 text-sm lg:hidden'>
+                {pageActions}
+              </aside>
+            }
+            comments
+            slug={params.slug}
+            toc={toc}
+          >
             <Mdx components={{ ...mdxComponents, GitHubCode }} />
           </MdxContent>
           <div className='lg:supports-timeline-scroll:scroll-fade-effect-y flex flex-col gap-4 p-4 text-sm lg:sticky lg:top-[4rem] lg:h-[calc(100vh-4rem)] lg:w-[250px] lg:self-start lg:overflow-y-auto lg:border-border lg:border-l lg:border-dashed'>
-            <div>
-              <p className='mb-1 text-muted-foreground text-sm'>Written by</p>
-              <p className='font-medium'>{page.data.author ?? 'Unknown'}</p>
-            </div>
-            <div>
-              <p className='mb-1 text-muted-foreground text-sm'>Created At</p>
-              <p className='font-medium'>
-                {new Date(page.data.date).toDateString()}
-              </p>
-            </div>
-            {lastUpdate && (
-              <div>
-                <p className='mb-1 text-muted-foreground text-sm'>Updated At</p>
-                <p className='font-medium'>{lastUpdate.toDateString()}</p>
-              </div>
-            )}
-            <div className='flex flex-col gap-2'>
-              <LLMCopyButtonWithViewOptions
-                githubUrl={`https://github.com/${owner}/${repo}/blob/main/content/blog/${params.slug}.mdx`}
-                markdownUrl={`/blog.mdx/${params.slug}`}
-              />
-              <ShareMenu title={page.data.title ?? 'Untitled'} url={page.url} />
-            </div>
+            {pageActions}
           </div>
         </article>
       </SectionBody>

--- a/src/components/mdx-layout.tsx
+++ b/src/components/mdx-layout.tsx
@@ -32,6 +32,7 @@ export const InlineTocBlock = ({ items, className }: InlineTocBlockProps) =>
   )
 
 interface MdxContentProps {
+  beforeComments?: ReactNode
   children: ReactNode
   className?: string
   comments?: boolean
@@ -43,6 +44,7 @@ interface MdxContentProps {
 
 export const MdxContent = ({
   children,
+  beforeComments,
   toc,
   comments,
   slug,
@@ -60,6 +62,7 @@ export const MdxContent = ({
     >
       {children}
     </div>
+    {beforeComments}
     {comments && slug ? (
       <PostComments
         className={cn(


### PR DESCRIPTION
On mobile, show author metadata plus Copy Page and Share controls directly before the comments section. Desktop retains the existing sticky article sidebar.