### PR TITLE
fix(search): stop command palette scrolling with the page

### DIFF
--- a/src/app/layout.client.tsx
+++ b/src/app/layout.client.tsx
@@ -2,7 +2,6 @@
 
 import { useParams } from 'next/navigation'
 import type { ReactNode } from 'react'
-import { cn } from '@/lib/utils'
 
 export function Body({
   children,
@@ -12,10 +11,10 @@ export function Body({
   const mode = useMode()
 
   return (
-    <body
-      className={cn(mode, 'relative flex min-h-svh flex-col overflow-x-hidden')}
-    >
-      {children}
+    <body className={mode}>
+      <div className='relative flex min-h-svh flex-col overflow-x-hidden'>
+        {children}
+      </div>
     </body>
   )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,6 +44,7 @@ export const metadata = createMetadata({
 })
 
 export const viewport: Viewport = {
+  interactiveWidget: 'resizes-content',
   maximumScale: 1,
   themeColor: [
     { color: '#0A0A0A', media: '(prefers-color-scheme: dark)' },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,7 +44,6 @@ export const metadata = createMetadata({
 })
 
 export const viewport: Viewport = {
-  interactiveWidget: 'resizes-content',
   maximumScale: 1,
   themeColor: [
     { color: '#0A0A0A', media: '(prefers-color-scheme: dark)' },

--- a/src/components/search/dialog.tsx
+++ b/src/components/search/dialog.tsx
@@ -3,7 +3,6 @@ import { useSound } from '@web-kits/audio/react'
 import { useDocsSearch } from 'fumadocs-core/search/client'
 import type { SharedProps } from 'fumadocs-ui/components/dialog/search'
 import { useI18n } from 'fumadocs-ui/contexts/i18n'
-import { useLenis } from 'lenis/react'
 import { useRouter } from 'next/navigation'
 import { useTheme } from 'next-themes'
 import { Fragment, useEffect, useMemo, useRef } from 'react'
@@ -46,7 +45,6 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
   const playNavigate = useSound(keyPress)
   const lastNavSoundAtRef = useRef(0)
   const inputRef = useRef<HTMLInputElement>(null)
-  const lenis = useLenis()
 
   useEffect(() => {
     if (!open) {
@@ -55,22 +53,6 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
 
     playOpen()
   }, [open, playOpen])
-
-  useEffect(() => {
-    if (!lenis) {
-      return
-    }
-
-    if (open) {
-      lenis.stop()
-    } else {
-      lenis.start()
-    }
-
-    return () => {
-      lenis.start()
-    }
-  }, [open, lenis])
 
   useEffect(() => {
     if (!open) {

--- a/src/components/search/dialog.tsx
+++ b/src/components/search/dialog.tsx
@@ -72,29 +72,6 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
     }
   }, [open, lenis])
 
-  useEffect(() => {
-    if (!open) {
-      return
-    }
-
-    const scrollY = window.scrollY
-    const { body } = document
-    const previousPosition = body.style.position
-    const previousTop = body.style.top
-    const previousWidth = body.style.width
-
-    body.style.position = 'fixed'
-    body.style.top = `-${scrollY}px`
-    body.style.width = '100%'
-
-    return () => {
-      body.style.position = previousPosition
-      body.style.top = previousTop
-      body.style.width = previousWidth
-      window.scrollTo(0, scrollY)
-    }
-  }, [open])
-
   const { search, setSearch, query } = useDocsSearch({ locale, type: 'fetch' })
   const allPages = usePages()
 

--- a/src/components/search/dialog.tsx
+++ b/src/components/search/dialog.tsx
@@ -45,6 +45,7 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
   const playCollapse = useSound(collapse)
   const playNavigate = useSound(keyPress)
   const lastNavSoundAtRef = useRef(0)
+  const inputRef = useRef<HTMLInputElement>(null)
   const lenis = useLenis()
 
   useEffect(() => {
@@ -182,6 +183,10 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
       <DialogContent
         className='top-0 flex max-w-full translate-y-0 flex-col rounded-none! border-none bg-popover bg-clip-padding p-2 shadow-2xl sm:top-1/3 sm:max-w-lg sm:rounded-xl! sm:pb-11 sm:ring-4 sm:ring-neutral-200/80 dark:bg-neutral-900 dark:sm:ring-neutral-800'
         data-lenis-prevent
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          inputRef.current?.focus({ preventScroll: true })
+        }}
         showCloseButton={false}
       >
         <DialogHeader className='sr-only'>
@@ -196,6 +201,7 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
           <CommandInput
             onValueChange={setSearch}
             placeholder='Type a command or search...'
+            ref={inputRef}
             value={search}
           />
 

--- a/src/components/search/dialog.tsx
+++ b/src/components/search/dialog.tsx
@@ -72,6 +72,29 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
     }
   }, [open, lenis])
 
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const scrollY = window.scrollY
+    const { body } = document
+    const previousPosition = body.style.position
+    const previousTop = body.style.top
+    const previousWidth = body.style.width
+
+    body.style.position = 'fixed'
+    body.style.top = `-${scrollY}px`
+    body.style.width = '100%'
+
+    return () => {
+      body.style.position = previousPosition
+      body.style.top = previousTop
+      body.style.width = previousWidth
+      window.scrollTo(0, scrollY)
+    }
+  }, [open])
+
   const { search, setSearch, query } = useDocsSearch({ locale, type: 'fetch' })
   const allPages = usePages()
 

--- a/src/components/search/dialog.tsx
+++ b/src/components/search/dialog.tsx
@@ -72,6 +72,34 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
     }
   }, [open, lenis])
 
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    // Radix's own scroll lock sets overflow:hidden on <body> while a dialog
+    // is open. On iOS Safari, a fixed-position descendant of an ancestor
+    // with non-visible overflow doesn't stay pinned to the viewport - it
+    // scrolls with the page. Locking body with position:fixed sidesteps
+    // that regardless of which overflow rule triggers it.
+    const scrollY = window.scrollY
+    const { body } = document
+    const previousPosition = body.style.position
+    const previousTop = body.style.top
+    const previousWidth = body.style.width
+
+    body.style.position = 'fixed'
+    body.style.top = `-${scrollY}px`
+    body.style.width = '100%'
+
+    return () => {
+      body.style.position = previousPosition
+      body.style.top = previousTop
+      body.style.width = previousWidth
+      window.scrollTo(0, scrollY)
+    }
+  }, [open])
+
   const { search, setSearch, query } = useDocsSearch({ locale, type: 'fetch' })
   const allPages = usePages()
 

--- a/src/components/search/dialog.tsx
+++ b/src/components/search/dialog.tsx
@@ -3,6 +3,7 @@ import { useSound } from '@web-kits/audio/react'
 import { useDocsSearch } from 'fumadocs-core/search/client'
 import type { SharedProps } from 'fumadocs-ui/components/dialog/search'
 import { useI18n } from 'fumadocs-ui/contexts/i18n'
+import { useLenis } from 'lenis/react'
 import { useRouter } from 'next/navigation'
 import { useTheme } from 'next-themes'
 import { Fragment, useEffect, useMemo, useRef } from 'react'
@@ -44,6 +45,7 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
   const playCollapse = useSound(collapse)
   const playNavigate = useSound(keyPress)
   const lastNavSoundAtRef = useRef(0)
+  const lenis = useLenis()
 
   useEffect(() => {
     if (!open) {
@@ -52,6 +54,22 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
 
     playOpen()
   }, [open, playOpen])
+
+  useEffect(() => {
+    if (!lenis) {
+      return
+    }
+
+    if (open) {
+      lenis.stop()
+    } else {
+      lenis.start()
+    }
+
+    return () => {
+      lenis.start()
+    }
+  }, [open, lenis])
 
   const { search, setSearch, query } = useDocsSearch({ locale, type: 'fetch' })
   const allPages = usePages()

--- a/src/components/search/dialog.tsx
+++ b/src/components/search/dialog.tsx
@@ -3,6 +3,7 @@ import { useSound } from '@web-kits/audio/react'
 import { useDocsSearch } from 'fumadocs-core/search/client'
 import type { SharedProps } from 'fumadocs-ui/components/dialog/search'
 import { useI18n } from 'fumadocs-ui/contexts/i18n'
+import { useLenis } from 'lenis/react'
 import { useRouter } from 'next/navigation'
 import { useTheme } from 'next-themes'
 import { Fragment, useEffect, useMemo, useRef } from 'react'
@@ -44,7 +45,8 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
   const playCollapse = useSound(collapse)
   const playNavigate = useSound(keyPress)
   const lastNavSoundAtRef = useRef(0)
-  const inputRef = useRef<HTMLInputElement>(null)
+  const commandInput = useRef<HTMLInputElement>(null)
+  const lenis = useLenis()
 
   useEffect(() => {
     if (!open) {
@@ -55,15 +57,26 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
   }, [open, playOpen])
 
   useEffect(() => {
+    if (!lenis) {
+      return
+    }
+
+    if (open) {
+      lenis.stop()
+    } else {
+      lenis.start()
+    }
+
+    return () => {
+      lenis.start()
+    }
+  }, [open, lenis])
+
+  useEffect(() => {
     if (!open) {
       return
     }
 
-    // Radix's own scroll lock sets overflow:hidden on <body> while a dialog
-    // is open. On iOS Safari, a fixed-position descendant of an ancestor
-    // with non-visible overflow doesn't stay pinned to the viewport - it
-    // scrolls with the page. Locking body with position:fixed sidesteps
-    // that regardless of which overflow rule triggers it.
     const scrollY = window.scrollY
     const { body } = document
     const previousPosition = body.style.position
@@ -195,7 +208,7 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
         data-lenis-prevent
         onOpenAutoFocus={(event) => {
           event.preventDefault()
-          inputRef.current?.focus({ preventScroll: true })
+          commandInput.current?.focus({ preventScroll: true })
         }}
         showCloseButton={false}
       >
@@ -211,7 +224,7 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
           <CommandInput
             onValueChange={setSearch}
             placeholder='Type a command or search...'
-            ref={inputRef}
+            ref={commandInput}
             value={search}
           />
 


### PR DESCRIPTION
## Summary
Scrolling the page while the cmdk search dialog (`SearchDialog`) was open scrolled the background underneath the palette, making it impossible to navigate items reliably. Two independent causes, confirmed fixed:

**Desktop (wheel scroll).** [Lenis](https://github.com/darkroomengineering/lenis) drives smooth scroll programmatically via JS, bypassing Radix `Dialog`'s native `overflow: hidden` scroll lock on `<body>`. Fixed by calling `lenis.stop()`/`lenis.start()` on dialog open/close via `useLenis` (`src/components/search/dialog.tsx`).

**Mobile (iOS Safari).** Confirmed via a screen recording that the *entire* dialog (search input included) slid up together with the background page on a plain swipe — no keyboard involved. Root cause: `<body>` had `overflow-x-hidden`/`position: relative` set directly on it (`src/app/layout.client.tsx`), *and* Radix's own scroll lock (`react-remove-scroll`) additionally sets `overflow: hidden` + `data-scroll-locked` on `<body>` itself whenever any dialog is open. Radix `Dialog` portals its content as a **direct child of `<body>`**, and iOS Safari has a longstanding WebKit bug where `position: fixed` descendants of an ancestor with non-visible `overflow` don't stay pinned to the true viewport.

Fixed with two complementary changes:
1. Moved the `overflow-x-hidden`/`relative`/`min-h-svh` styling off `<body>` onto an inner wrapper `<div>`, so our own styling doesn't contribute to the problem.
2. Lock `<body>` with `position: fixed` (the standard [body-scroll-lock](https://github.com/willmcpo/body-scroll-lock) technique) while the dialog is open, which sidesteps the WebKit bug regardless of whether Radix's own lock still sets `overflow: hidden` on body.

Also focuses the search input with `focus({ preventScroll: true })` via `onOpenAutoFocus` as cheap defense-in-depth against any focus-triggered scroll racing ahead of the body lock.

Confirmed working on the reporter's iPhone (iOS Safari) after the final combination of fixes.

## Test plan
- [x] `bun run check` (ultracite) passes
- [x] `bunx tsc --noEmit` shows no new errors (pre-existing unrelated errors only, from a missing local image asset and generated Next.js route types not present in the sandbox)
- [x] Verified locally that `<body>` carries no `overflow`/`position` styling outside of the dialog being open, and the wrapper `div` carries the layout styling instead, with no visual regression
- [x] Verified locally that the body lock and Radix's own scroll lock coexist correctly, and scroll position restores precisely on close
- [x] **Confirmed fixed on a physical iPhone (iOS Safari)** by the reporter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search dialog behavior by automatically focusing the search field when opened.
  * Prevented background page scrolling while the search dialog is open.
  * Preserved the page’s scroll position and body styling after closing the dialog.
* **Style**
  * Improved layout handling to ensure page styling remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->