### PR TITLE
perf: code-split AI search/Clippy panel and custom cursor out of the critical bundle

### DIFF
--- a/src/app/provider.tsx
+++ b/src/app/provider.tsx
@@ -2,16 +2,27 @@
 
 import { ProgressProvider } from '@bprogress/next/app'
 import { SoundProvider } from '@web-kits/audio/react'
+import dynamic from 'next/dynamic'
 import { NuqsAdapter } from 'nuqs/adapters/next/app'
 import type { ReactNode } from 'react'
-import { AISearchTrigger } from '@/components/ai/ai-search-trigger'
-import { AISearch } from '@/components/ai/chat'
+import { AISearchProvider } from '@/components/ai/chat-context'
 import Analytics from '@/components/analytics'
 import { MobileNav } from '@/components/mobile-nav'
-import { SmoothCursor } from '@/components/smooth-cursor'
 import { TailwindIndicator } from '@/components/tailwind-indicator'
 import { Toaster } from '@/components/ui/sonner'
 import { TooltipProvider } from '@/components/ui/tooltip'
+
+// Both are purely client-side extras (AI chat/Clippy panel, custom cursor)
+// with no SSR output, so they're code-split out of the initial bundle and
+// only fetched once the client is idle/hydrated.
+const AISearchHeavy = dynamic(
+  () => import('@/components/ai/chat').then((mod) => mod.AISearchHeavy),
+  { ssr: false }
+)
+const SmoothCursor = dynamic(
+  () => import('@/components/smooth-cursor').then((mod) => mod.SmoothCursor),
+  { ssr: false }
+)
 
 export function Provider({
   children,
@@ -20,7 +31,7 @@ export function Provider({
 }): React.ReactElement {
   return (
     <SoundProvider>
-      <AISearch>
+      <AISearchProvider>
         <ProgressProvider
           color='var(--color-primary)'
           delay={200}
@@ -36,9 +47,9 @@ export function Provider({
             <NuqsAdapter>{children}</NuqsAdapter>
           </TooltipProvider>
         </ProgressProvider>
-        <AISearchTrigger />
         <MobileNav />
-      </AISearch>
+        <AISearchHeavy />
+      </AISearchProvider>
       <Analytics />
       <Toaster position='top-center' />
       <TailwindIndicator />

--- a/src/components/ai/ai-search-trigger.tsx
+++ b/src/components/ai/ai-search-trigger.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import dynamic from 'next/dynamic'
 import { useEffect } from 'react'
-import { useAISearchContext } from '@/components/ai/chat'
+import { useAISearchContext } from '@/components/ai/chat-context'
 import { useClippy } from '@/components/clippy'
 import { animations } from '@/components/clippy/constants'
 import { playAnimation } from '@/components/clippy/utils'
@@ -12,7 +11,7 @@ const getPosition = () => ({
   y: window.innerHeight - 100,
 })
 
-function ClippyTriggerInner() {
+export function AISearchTrigger() {
   const { setOpen } = useAISearchContext()
   const { agent } = useClippy()
 
@@ -67,8 +66,3 @@ function ClippyTriggerInner() {
 
   return null
 }
-
-export const AISearchTrigger = dynamic(
-  () => Promise.resolve(ClippyTriggerInner),
-  { ssr: false }
-)

--- a/src/components/ai/chat-context.tsx
+++ b/src/components/ai/chat-context.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import {
+  createContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  use,
+  useMemo,
+  useState,
+} from 'react'
+
+interface AISearchState {
+  context: string | null
+  open: boolean
+  setContext: Dispatch<SetStateAction<string | null>>
+  setOpen: Dispatch<SetStateAction<boolean>>
+}
+
+const AISearchContext = createContext<AISearchState | null>(null)
+
+export function useAISearchContext() {
+  const ctx = use(AISearchContext)
+  if (!ctx) {
+    throw new Error('useAISearchContext must be used within AISearchProvider')
+  }
+  return ctx
+}
+
+export function AISearchProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false)
+  const [context, setContext] = useState<string | null>(null)
+
+  const value = useMemo(
+    () => ({ context, open, setContext, setOpen }),
+    [context, open]
+  )
+
+  return <AISearchContext value={value}>{children}</AISearchContext>
+}

--- a/src/components/ai/chat.tsx
+++ b/src/components/ai/chat.tsx
@@ -9,15 +9,11 @@ import { buttonVariants } from 'fumadocs-ui/components/ui/button'
 import {
   type ComponentProps,
   createContext,
-  type Dispatch,
   memo,
-  type ReactNode,
-  type SetStateAction,
   type SyntheticEvent,
   use,
   useEffect,
   useEffectEvent,
-  useMemo,
   useRef,
   useState,
 } from 'react'
@@ -28,6 +24,8 @@ import {
   getToolsRequiringConfirmation,
   type ToolName,
 } from '@/app/api/chat/utils/tools/confirmation'
+import { AISearchTrigger } from '@/components/ai/ai-search-trigger'
+import { useAISearchContext } from '@/components/ai/chat-context'
 import {
   AIContactForm,
   AIContactFormSkeleton,
@@ -49,34 +47,18 @@ import { cn } from '@/lib/utils'
 import { Markdown } from './markdown'
 import { MessageMetadata } from './message-metadata'
 
-const AISearchContext = createContext<{
-  open: boolean
-  setOpen: Dispatch<SetStateAction<boolean>>
-  chat: UseChatHelpers<MyUIMessage>
-  context: string | null
-  setContext: Dispatch<SetStateAction<string | null>>
-} | null>(null)
+const ChatContext = createContext<UseChatHelpers<MyUIMessage> | null>(null)
 
-export function useAISearchContext() {
-  const ctx = use(AISearchContext)
+export function useChatContext() {
+  const ctx = use(ChatContext)
   if (!ctx) {
-    throw new Error('useAISearchContext must be used within AISearch')
+    throw new Error('useChatContext must be used within AISearchHeavy')
   }
   return ctx
 }
 
-export function useChatContext() {
-  const ctx = use(AISearchContext)
-  if (!ctx) {
-    throw new Error('useChatContext must be used within AISearch')
-  }
-  return ctx.chat
-}
-
-export function AISearch({ children }: { children: ReactNode }) {
+export function AISearchHeavy() {
   const isMobile = useIsMobile()
-  const [open, setOpen] = useState(false)
-  const [context, setContext] = useState<string | null>(null)
   const playError = useSound(errorSound)
   const playSuccess = useSound(success)
   const playDelete = useSound(deleteSound)
@@ -99,27 +81,17 @@ export function AISearch({ children }: { children: ReactNode }) {
 
   return (
     <ClippyProvider agent={isMobile ? undefined : Rover}>
-      <AISearchContext
-        value={useMemo(
-          () => ({
-            chat,
-            context,
-            open,
-            setContext,
-            setOpen,
-          }),
-          [chat, context, open]
-        )}
-      >
-        {children}
+      <ChatContext value={chat}>
+        <AISearchTrigger />
         <AISearchPanel />
-      </AISearchContext>
+      </ChatContext>
     </ClippyProvider>
   )
 }
 
 function Header() {
-  const { setOpen, chat, setContext } = useAISearchContext()
+  const { setOpen, setContext } = useAISearchContext()
+  const chat = useChatContext()
   const playNewChat = useSound(toggleOn)
 
   return (

--- a/src/components/ai/selection-context-menu.tsx
+++ b/src/components/ai/selection-context-menu.tsx
@@ -17,7 +17,7 @@ import {
 } from 'react'
 import { createPortal } from 'react-dom'
 import { cn } from '@/lib/utils'
-import { useAISearchContext } from './chat'
+import { useAISearchContext } from './chat-context'
 
 interface PopupState {
   text: string

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -3,7 +3,7 @@
 import { Presence } from '@radix-ui/react-presence'
 import { useSearchContext } from 'fumadocs-ui/contexts/search'
 import { useState } from 'react'
-import { useAISearchContext } from '@/components/ai/chat'
+import { useAISearchContext } from '@/components/ai/chat-context'
 import { FloatingPill } from '@/components/mobile-nav/floating-pill'
 import { MenuPanel } from '@/components/mobile-nav/menu-panel'
 


### PR DESCRIPTION
## Summary

I set out to run Lighthouse against https://www.techwithanirudh.com/, but headless Chrome gets a TCP reset on that domain specifically (confirmed the same proxy+Chrome setup loads `example.com` fine) — consistent with the Vercel BotID protection already wired into `next.config.ts` blocking automated/headless traffic by design. Since a live audit wasn't possible from this environment, I did a code-level pass instead and found that the AI search/Clippy chat panel and the custom smooth cursor were mounted eagerly on every single page via `Provider`, shipping in the initial JS bundle and hydrating up front even though most visits never open the search panel.

- Split `AISearch`'s state (`open`/`context`) into a new lightweight `src/components/ai/chat-context.tsx` provider. It still wraps the whole app (needed by mobile nav / text-selection UI to open the panel on demand), but has no heavy dependencies (no `useChat`, no Clippy, no sound effects) — so it stays eager and cheap.
- The heavy chat/Clippy internals (`useChat`, `ClippyProvider` + Rover agent, message list, markdown rendering, sound effects) now live in `AISearchHeavy`, loaded via `next/dynamic(..., { ssr: false })` from `src/app/provider.tsx`, as does `SmoothCursor`. Both now load as separate chunks after hydration instead of blocking the initial render.
- Simplified the redundant no-op `dynamic(() => Promise.resolve(...))` wrapper in `ai-search-trigger.tsx`, since it now lives inside an already client-only, dynamically-loaded chunk.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run check` (lint) passes
- [x] `next build` compiles successfully (fails later only on an unrelated, pre-existing missing `DATABASE_URL` during page-data collection — not present in this sandbox, unrelated to this change)
- [x] Verified via `bun run dev` + headless Chromium: home page renders with no console/hydration errors, `Ctrl+/` opens the AI search panel correctly, and the Clippy/Rover sprite assets load successfully (200s) through the new dynamic import

---
_Generated by [Claude Code](https://claude.ai/code/session_018qucW2awhSZhhLYgRR7Jz4)_