### PR TITLE
fix(pagination): center page numbers + revert search-dialog scroll-lock (#66)

### DIFF
--- a/src/app/layout.client.tsx
+++ b/src/app/layout.client.tsx
@@ -2,6 +2,7 @@
 
 import { useParams } from 'next/navigation'
 import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
 
 export function Body({
   children,
@@ -11,10 +12,10 @@ export function Body({
   const mode = useMode()
 
   return (
-    <body className={mode}>
-      <div className='relative flex min-h-svh flex-col overflow-x-clip'>
-        {children}
-      </div>
+    <body
+      className={cn(mode, 'relative flex min-h-svh flex-col overflow-x-hidden')}
+    >
+      {children}
     </body>
   )
 }

--- a/src/app/layout.client.tsx
+++ b/src/app/layout.client.tsx
@@ -2,6 +2,7 @@
 
 import { useParams } from 'next/navigation'
 import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
 
 export function Body({
   children,
@@ -11,10 +12,8 @@ export function Body({
   const mode = useMode()
 
   return (
-    <body className={mode}>
-      <div className='relative flex min-h-svh flex-col overflow-x-hidden'>
-        {children}
-      </div>
+    <body className={cn(mode, 'overflow-x-hidden')}>
+      <div className='relative flex min-h-svh flex-col'>{children}</div>
     </body>
   )
 }

--- a/src/app/layout.client.tsx
+++ b/src/app/layout.client.tsx
@@ -12,8 +12,10 @@ export function Body({
   const mode = useMode()
 
   return (
-    <body className={cn(mode, 'overflow-x-hidden')}>
-      <div className='relative flex min-h-svh flex-col'>{children}</div>
+    <body
+      className={cn(mode, 'relative flex min-h-svh flex-col overflow-x-hidden')}
+    >
+      {children}
     </body>
   )
 }

--- a/src/components/numbered-pagination.tsx
+++ b/src/components/numbered-pagination.tsx
@@ -36,91 +36,85 @@ function NumberedPagination({
 
   return (
     <Pagination>
-      <PaginationContent className='grid w-full grid-cols-[1fr_auto_1fr] items-center gap-0 -space-x-px rtl:space-x-reverse'>
-        <div className='flex'>
+      <PaginationContent className='grid w-full grid-cols-[1fr_auto_1fr] items-center gap-0'>
+        <PaginationItem className='flex'>
           {currentPage > 1 && (
-            <PaginationItem>
-              <Button
-                aria-label='Go to previous page'
-                className='shadow-none hover:z-10 focus-visible:z-10'
-                onClick={handlePageChange(currentPage - 1)}
-                shape='square'
-                size='icon'
-                variant='ghost'
-              >
-                <Icons.chevronLeft
-                  aria-hidden='true'
-                  size={16}
-                  strokeWidth={2}
-                />
-              </Button>
-            </PaginationItem>
+            <Button
+              aria-label='Go to previous page'
+              className='shadow-none hover:z-10 focus-visible:z-10'
+              onClick={handlePageChange(currentPage - 1)}
+              shape='square'
+              size='icon'
+              variant='ghost'
+            >
+              <Icons.chevronLeft aria-hidden='true' size={16} strokeWidth={2} />
+            </Button>
           )}
-        </div>
+        </PaginationItem>
 
-        <div className='inline-flex justify-self-center'>
-          {showLeftEllipsis && (
-            <PaginationItem>
-              <Button
-                className='pointer-events-none shadow-none'
-                shape='square'
-                size='icon'
-                variant='ghost'
-              >
-                ...
-              </Button>
-            </PaginationItem>
-          )}
+        <PaginationItem className='justify-self-center'>
+          <ul className='inline-flex items-center gap-1 -space-x-px rtl:space-x-reverse'>
+            {showLeftEllipsis && (
+              <PaginationItem>
+                <Button
+                  className='pointer-events-none shadow-none'
+                  shape='square'
+                  size='icon'
+                  variant='ghost'
+                >
+                  ...
+                </Button>
+              </PaginationItem>
+            )}
 
-          {pages.map((page) => (
-            <PaginationItem className='w-max' key={page}>
-              <Button
-                aria-current={page === currentPage ? 'page' : undefined}
-                className='shadow-none hover:z-10 focus-visible:z-10'
-                onClick={handlePageChange(page)}
-                shape='square'
-                size='icon'
-                variant={page === currentPage ? 'default' : 'ghost'}
-              >
-                {page}
-              </Button>
-            </PaginationItem>
-          ))}
+            {pages.map((page) => (
+              <PaginationItem className='w-max' key={page}>
+                <Button
+                  aria-current={page === currentPage ? 'page' : undefined}
+                  className='shadow-none hover:z-10 focus-visible:z-10'
+                  onClick={handlePageChange(page)}
+                  shape='square'
+                  size='icon'
+                  variant={page === currentPage ? 'default' : 'ghost'}
+                >
+                  {page}
+                </Button>
+              </PaginationItem>
+            ))}
 
-          {showRightEllipsis && (
-            <PaginationItem>
-              <Button
-                className='pointer-events-none shadow-none'
-                shape='square'
-                size='icon'
-                variant='ghost'
-              >
-                ...
-              </Button>
-            </PaginationItem>
-          )}
-        </div>
+            {showRightEllipsis && (
+              <PaginationItem>
+                <Button
+                  className='pointer-events-none shadow-none'
+                  shape='square'
+                  size='icon'
+                  variant='ghost'
+                >
+                  ...
+                </Button>
+              </PaginationItem>
+            )}
+          </ul>
+        </PaginationItem>
 
-        <div className='flex justify-end'>
+        <PaginationItem className='flex justify-end'>
           {currentPage < totalPages && (
-            <PaginationItem>
-              <Button
-                aria-label='Go to next page'
-                className='shadow-none hover:z-10 focus-visible:z-10'
-                onClick={handlePageChange(currentPage + 1)}
-                shape='square'
-                size='icon'
-                variant='ghost'
-              >
-                <Icons.chevronRight
-                  aria-hidden='true'
-                  size={16}
-                  strokeWidth={2}
-                />
-              </Button>
-            </PaginationItem>
+            <Button
+              aria-label='Go to next page'
+              className='shadow-none hover:z-10 focus-visible:z-10'
+              onClick={handlePageChange(currentPage + 1)}
+              shape='square'
+              size='icon'
+              variant='ghost'
+            >
+              <Icons.chevronRight
+                aria-hidden='true'
+                size={16}
+                strokeWidth={2}
+              />
+            </Button>
           )}
-        </div>
+        </PaginationItem>
       </PaginationContent>
     </Pagination>
   )

--- a/src/components/numbered-pagination.tsx
+++ b/src/components/numbered-pagination.tsx
@@ -36,23 +36,29 @@ function NumberedPagination({
 
   return (
     <Pagination>
-      <PaginationContent className='inline-flex w-full gap-0 -space-x-px rtl:space-x-reverse'>
-        {currentPage > 1 && (
-          <PaginationItem>
-            <Button
-              aria-label='Go to previous page'
-              className='shadow-none hover:z-10 focus-visible:z-10'
-              onClick={handlePageChange(currentPage - 1)}
-              shape='square'
-              size='icon'
-              variant='ghost'
-            >
-              <Icons.chevronLeft aria-hidden='true' size={16} strokeWidth={2} />
-            </Button>
-          </PaginationItem>
-        )}
+      <PaginationContent className='grid w-full grid-cols-[1fr_auto_1fr] items-center gap-0 -space-x-px rtl:space-x-reverse'>
+        <div className='flex'>
+          {currentPage > 1 && (
+            <PaginationItem>
+              <Button
+                aria-label='Go to previous page'
+                className='shadow-none hover:z-10 focus-visible:z-10'
+                onClick={handlePageChange(currentPage - 1)}
+                shape='square'
+                size='icon'
+                variant='ghost'
+              >
+                <Icons.chevronLeft
+                  aria-hidden='true'
+                  size={16}
+                  strokeWidth={2}
+                />
+              </Button>
+            </PaginationItem>
+          )}
+        </div>
 
-        <div className='inline-flex w-full justify-center'>
+        <div className='inline-flex justify-self-center'>
           {showLeftEllipsis && (
             <PaginationItem>
               <Button
@@ -95,24 +101,26 @@ function NumberedPagination({
           )}
         </div>
 
-        {currentPage < totalPages && (
-          <PaginationItem>
-            <Button
-              aria-label='Go to next page'
-              className='shadow-none hover:z-10 focus-visible:z-10'
-              onClick={handlePageChange(currentPage + 1)}
-              shape='square'
-              size='icon'
-              variant='ghost'
-            >
-              <Icons.chevronRight
-                aria-hidden='true'
-                size={16}
-                strokeWidth={2}
-              />
-            </Button>
-          </PaginationItem>
-        )}
+        <div className='flex justify-end'>
+          {currentPage < totalPages && (
+            <PaginationItem>
+              <Button
+                aria-label='Go to next page'
+                className='shadow-none hover:z-10 focus-visible:z-10'
+                onClick={handlePageChange(currentPage + 1)}
+                shape='square'
+                size='icon'
+                variant='ghost'
+              >
+                <Icons.chevronRight
+                  aria-hidden='true'
+                  size={16}
+                  strokeWidth={2}
+                />
+              </Button>
+            </PaginationItem>
+          )}
+        </div>
       </PaginationContent>
     </Pagination>
   )

--- a/src/components/search/dialog.tsx
+++ b/src/components/search/dialog.tsx
@@ -3,7 +3,6 @@ import { useSound } from '@web-kits/audio/react'
 import { useDocsSearch } from 'fumadocs-core/search/client'
 import type { SharedProps } from 'fumadocs-ui/components/dialog/search'
 import { useI18n } from 'fumadocs-ui/contexts/i18n'
-import { useLenis } from 'lenis/react'
 import { useRouter } from 'next/navigation'
 import { useTheme } from 'next-themes'
 import { Fragment, useEffect, useMemo, useRef } from 'react'
@@ -45,8 +44,6 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
   const playCollapse = useSound(collapse)
   const playNavigate = useSound(keyPress)
   const lastNavSoundAtRef = useRef(0)
-  const commandInput = useRef<HTMLInputElement>(null)
-  const lenis = useLenis()
 
   useEffect(() => {
     if (!open) {
@@ -55,45 +52,6 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
 
     playOpen()
   }, [open, playOpen])
-
-  useEffect(() => {
-    if (!lenis) {
-      return
-    }
-
-    if (open) {
-      lenis.stop()
-    } else {
-      lenis.start()
-    }
-
-    return () => {
-      lenis.start()
-    }
-  }, [open, lenis])
-
-  useEffect(() => {
-    if (!open) {
-      return
-    }
-
-    const scrollY = window.scrollY
-    const { body } = document
-    const previousPosition = body.style.position
-    const previousTop = body.style.top
-    const previousWidth = body.style.width
-
-    body.style.position = 'fixed'
-    body.style.top = `-${scrollY}px`
-    body.style.width = '100%'
-
-    return () => {
-      body.style.position = previousPosition
-      body.style.top = previousTop
-      body.style.width = previousWidth
-      window.scrollTo(0, scrollY)
-    }
-  }, [open])
 
   const { search, setSearch, query } = useDocsSearch({ locale, type: 'fetch' })
   const allPages = usePages()
@@ -206,10 +164,6 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
       <DialogContent
         className='top-0 flex max-w-full translate-y-0 flex-col rounded-none! border-none bg-popover bg-clip-padding p-2 shadow-2xl sm:top-1/3 sm:max-w-lg sm:rounded-xl! sm:pb-11 sm:ring-4 sm:ring-neutral-200/80 dark:bg-neutral-900 dark:sm:ring-neutral-800'
         data-lenis-prevent
-        onOpenAutoFocus={(event) => {
-          event.preventDefault()
-          commandInput.current?.focus({ preventScroll: true })
-        }}
         showCloseButton={false}
       >
         <DialogHeader className='sr-only'>
@@ -224,7 +178,6 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
           <CommandInput
             onValueChange={setSearch}
             placeholder='Type a command or search...'
-            ref={commandInput}
             value={search}
           />
 


### PR DESCRIPTION
## Summary
- **Pagination fix (kept):** `PaginationContent` laid the previous button, page-number group, and next button out in a flex row where the page-number group used `w-full justify-center`. With one of the edge buttons hidden (first or last page), the group's available width changed but `justify-center` still centered it within that shrunk width instead of the full bar, visibly shifting the numbers off-center. Switched to a 3-column grid (`1fr auto 1fr`) with the prev/next buttons each in their own `PaginationItem` cell (empty when hidden) and the page numbers in a nested `<ul>` in the middle cell — keeps valid `ul`/`li` list semantics (per CodeRabbit's review) and centers the numbers on the whole bar in every state.
- **Revert of #66:** this branch originally fixed the sticky-TOC bug by moving `overflow-x-hidden` onto `<body>`, but `main` has since landed a better fix for that (#73, `overflow-x-clip` on the wrapper). Per explicit request, `3dd103c` (#66) is now fully reverted on top of that: `overflow-x-hidden` goes back onto `<body>` directly (no wrapper div) and the Lenis scroll-lock + iOS `position:fixed` workaround for the search command palette are removed.
  - **Known regression:** this is expected to reintroduce the iOS Safari bug #66 fixed — the search dialog's `position:fixed` content (portalled directly under `<body>`) not staying pinned to the viewport when `<body>` has non-visible overflow, and the desktop Lenis-driven scroll running behind the dialog while it's open.

Verified with Playwright against `bun dev`: page numbers center consistently (±0.5px) across pages with and without the previous/next button, and no horizontal-scroll regression on `/`, `/blog/vscode-setup`, `/blog/gorkie-sandboxes`, and `/work`.

## Test plan
- [x] `bun run check` on the changed files
- [x] `bun run typecheck`
- [x] Manually verified pagination centering via Playwright against `bun dev`
- [ ] Manually verify search dialog behavior on iOS Safari (expected regression from the revert above)