### PR TITLE
fix(layout): use overflow-x-clip to fix sticky TOC broken by #66

### DIFF
--- a/src/app/layout.client.tsx
+++ b/src/app/layout.client.tsx
@@ -12,7 +12,7 @@ export function Body({
 
   return (
     <body className={mode}>
-      <div className='relative flex min-h-svh flex-col overflow-x-hidden'>
+      <div className='relative flex min-h-svh flex-col overflow-x-clip'>
         {children}
       </div>
     </body>


### PR DESCRIPTION
## Summary
- Follow-up to #66. That PR moved `overflow-x-hidden`/`relative`/`min-h-svh` from `<body>` onto an inner wrapper `<div>` to fix `position: fixed` Dialog content breaking on iOS Safari.
- Side effect: `overflow-x: hidden` on that wrapper forces `overflow-y` to compute as `auto` (the CSS ["overflow coupling" rule](https://gomakethings.com/articles/the-overflow-hidden-property-and-sticky-headers/) — if one axis is non-`visible`, the UA must treat the other as `auto`), turning the wrapper into a scroll container. Any `position: sticky` descendant (the blog TOC minimap, the blog sidebar) then sticks relative to that wrapper instead of the viewport, breaking the sticky effect.
- Fix: use `overflow-x: clip` instead of `overflow-x: hidden`. `clip` blocks horizontal overflow the same way, but is [explicitly exempt](https://www.terluinwebdesign.nl/en/blog/position-sticky-not-working-try-overflow-clip-not-overflow-hidden/) from the overflow-coupling rule, so it doesn't create a scroll container.
- Deliberately **not** reverting the overflow styling back onto `<body>` directly (an alternative fix suggested elsewhere): `<body>` needs to stay free of `overflow`/`position` styling for `position: fixed` content that Radix portals directly into it to stay pinned to the viewport on iOS Safari. Every overlay primitive in this codebase does this (`Dialog`, `AlertDialog`, `Popover`, `DropdownMenu`, `Select`, `HoverCard`, `Tooltip`) — reverting would re-expose all of them to the bug #66 fixed for just the search dialog.

## Test plan
- [x] `bun run check` (ultracite) passes
- [x] Verified locally that the wrapper's computed style is `overflow-x: clip; overflow-y: visible` (not `auto`), confirming no scroll container is created
- [x] Verified locally (headless browser, `2xl` viewport) that the blog TOC minimap now correctly clamps at `top: 56px` on scroll instead of scrolling away with the page
- [x] Verified no horizontal-scroll regression on the home page and a blog post (`document.documentElement.scrollWidth <= clientWidth` in both cases)
- [x] Regression-checked the search dialog's scroll lock from #66 still works (`scrollY` stays locked while the dialog is open, restores correctly on close)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QiLtbbCyGZjV94ui3gBtk3)_