### PR TITLE
fix(layout): stop route transitions from smooth-scrolling to top

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -101,6 +101,7 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
   return (
     <html
       className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+      data-scroll-behavior='smooth'
       lang='en'
       suppressHydrationWarning
     >


### PR DESCRIPTION
## Summary
- Root cause of "navigating to another page leaves it a bit scrolled down" (most visible on mobile after scrolling partway down a page before tapping a link): `src/styles/globals.css` applies `scroll-smooth` to `<html>` (for anchor-link jumps like TOC links). Next.js's own scroll-to-top reset on client-side navigation goes through that same `scroll-behavior: smooth` CSS instead of an instant jump, so every navigation briefly renders the new page at the *old* scroll offset and eases up to the top over the next ~1s.
- Confirmed with a Next.js dev-console warning: *"Detected `scroll-behavior: smooth` on the `<html>` element. To disable smooth scrolling during route transitions, add `data-scroll-behavior=\"smooth\"` to your `<html>` element."*
- Fix: add `data-scroll-behavior="smooth"` to `<html>` in `src/app/layout.tsx` — this is Next's documented opt-out. It makes Next's internal scroll resets use an instant jump while leaving the CSS `scroll-smooth` behavior for actual user-triggered anchor scrolls (TOC clicks, `#hash` links, etc.) untouched.
- Cross-checked against `ncdai/chanhdai.com` (similar Next.js/Fumadocs stack) — it has no `scroll-smooth`/`scroll-behavior` anywhere in its styles, which is why it never hits this.

Verified with Playwright on a mobile viewport (390×844): before the fix, `window.scrollY` after a client-side navigation started at the old page's scroll offset (e.g. 500px) and eased down to 0 over several hundred ms; after the fix, it snaps to `0` the instant the URL changes.

## Test plan
- [x] `bun run check` on the changed file
- [x] `bun run typecheck`
- [x] Verified via Playwright against `bun dev`: scroll position snaps to top immediately after client-side navigation (tested `/` → `/work` and `/blog` → `/blog/vscode-setup` on a mobile viewport)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmqTH96qCEC2QkuPbXMPpY)_