### PR TITLE
feat: improve contributions and TOC

### DIFF
--- a/src/app/(home)/_components/contributions.tsx
+++ b/src/app/(home)/_components/contributions.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+import { Suspense, use } from 'react'
+
+import { Icons } from '@/components/icons/icons'
 import {
   type Activity,
   ContributionGraph,
@@ -20,10 +23,11 @@ import { useIsMobile } from '@/hooks/use-mobile'
 import { cn } from '@/lib/utils'
 
 interface ContributionsProps {
-  data: Activity[]
+  contributions: Promise<Activity[]>
 }
 
-const Contributions = ({ data }: ContributionsProps) => {
+const ContributionsGraph = ({ contributions }: ContributionsProps) => {
+  const data = use(contributions)
   const isMobile = useIsMobile()
   const blockSize = isMobile ? 10 : 23.5
 
@@ -35,12 +39,17 @@ const Contributions = ({ data }: ContributionsProps) => {
         whileInView={{ opacity: 1 }}
       >
         <ContributionGraph
+          aria-label='GitHub Contributions Graph'
           blockMargin={isMobile ? 1 : 2}
           blockSize={blockSize}
           className='w-full'
           data={data}
         >
-          <ContributionGraphCalendar className='overflow-auto'>
+          <ContributionGraphCalendar
+            aria-hidden
+            className='overflow-auto'
+            title='GitHub Contributions'
+          >
             {({ activity, dayIndex, weekIndex }) => (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -70,7 +79,14 @@ const Contributions = ({ data }: ContributionsProps) => {
             )}
           </ContributionGraphCalendar>
           <ContributionGraphFooter>
-            <ContributionGraphTotalCount />
+            <ContributionGraphTotalCount>
+              {({ totalCount }) => (
+                <div className='text-muted-foreground'>
+                  {totalCount.toLocaleString('en')} contributions in the past
+                  365 days.
+                </div>
+              )}
+            </ContributionGraphTotalCount>
             <ContributionGraphLegend>
               {({ level }) => (
                 <div
@@ -99,5 +115,17 @@ const Contributions = ({ data }: ContributionsProps) => {
     </Section>
   )
 }
+
+const Contributions = ({ contributions }: ContributionsProps) => (
+  <Suspense fallback={<ContributionsFallback />}>
+    <ContributionsGraph contributions={contributions} />
+  </Suspense>
+)
+
+export const ContributionsFallback = () => (
+  <Section className='relative flex h-45 w-full items-center justify-center p-6'>
+    <Icons.spinner className='size-4 animate-spin text-muted-foreground' />
+  </Section>
+)
 
 export default Contributions

--- a/src/app/(home)/blog/[slug]/page.client.tsx
+++ b/src/app/(home)/blog/[slug]/page.client.tsx
@@ -2,6 +2,7 @@
 
 import { Comments } from '@fuma-comment/react'
 import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
 import { Icons } from '@/components/icons/icons'
 import { Button } from '@/components/ui/button'
 import {
@@ -15,16 +16,16 @@ import { toast } from '@/lib/toast'
 import { cn } from '@/lib/utils'
 
 export function ShareMenu({ title, url }: { title: string; url: string }) {
-  const absoluteUrl =
-    typeof window === 'undefined'
-      ? url
-      : new URL(url, window.location.origin).toString()
+  const [canShare, setCanShare] = useState(false)
+  const encoded = encodeURIComponent(url)
 
-  const encoded = encodeURIComponent(absoluteUrl)
+  useEffect(() => {
+    setCanShare('share' in navigator)
+  }, [])
 
   const copyLink = async () => {
     try {
-      await navigator.clipboard.writeText(absoluteUrl)
+      await navigator.clipboard.writeText(url)
       toast.success('Link copied')
     } catch {
       toast.error('Unable to copy link')
@@ -73,11 +74,10 @@ export function ShareMenu({ title, url }: { title: string; url: string }) {
             Share on LinkedIn
           </a>
         </DropdownMenuItem>
-        {typeof navigator !== 'undefined' && 'share' in navigator && (
+        {canShare && (
           <DropdownMenuItem
-            onClick={(e) => {
-              e.preventDefault()
-              navigator.share({ title, url: absoluteUrl }).catch((error) => {
+            onClick={() => {
+              navigator.share({ title, url }).catch((error) => {
                 if (process.env.NODE_ENV !== 'production') {
                   console.error(error)
                 }

--- a/src/app/(home)/blog/[slug]/page.tsx
+++ b/src/app/(home)/blog/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { TOCProvider } from 'fumadocs-ui/components/toc'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { ShareMenu } from '@/app/(home)/blog/[slug]/page.client'
@@ -53,7 +54,7 @@ export default async function Page(props: {
   )
 
   return (
-    <>
+    <TOCProvider toc={toc}>
       <Header page={page} tags={tags} />
 
       <SectionBody className='flex'>
@@ -80,7 +81,7 @@ export default async function Page(props: {
         </article>
       </SectionBody>
       <PostJsonLd page={page} />
-    </>
+    </TOCProvider>
   )
 }
 

--- a/src/app/(home)/blog/[slug]/page.tsx
+++ b/src/app/(home)/blog/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import { TOCProvider } from 'fumadocs-ui/components/toc'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { ShareMenu } from '@/app/(home)/blog/[slug]/page.client'
@@ -54,14 +53,14 @@ export default async function Page(props: {
   )
 
   return (
-    <TOCProvider toc={toc}>
+    <>
       <Header page={page} tags={tags} />
 
       <SectionBody className='flex'>
-        <TOCMinimap />
+        <TOCMinimap items={toc} />
         <article className='flex min-h-full min-w-0 flex-1 flex-col lg:flex-row'>
           <div className='flex min-w-0 flex-1 flex-col'>
-            <TOCPopover />
+            <TOCPopover items={toc} />
             <MdxContent
               beforeComments={
                 <aside className='flex flex-col gap-4 border-border border-t border-dashed p-4 text-sm lg:hidden'>
@@ -81,7 +80,7 @@ export default async function Page(props: {
         </article>
       </SectionBody>
       <PostJsonLd page={page} />
-    </TOCProvider>
+    </>
   )
 }
 

--- a/src/app/(home)/blog/[slug]/page.tsx
+++ b/src/app/(home)/blog/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { GitHubCode } from '@/components/mdx/github-code'
 import { MdxContent } from '@/components/mdx-layout'
 import { SectionBody } from '@/components/section-body'
 import { TOCMinimap, TOCPopover } from '@/components/toc'
+import { baseUrl } from '@/constants'
 import { owner, repo } from '@/constants/config/github'
 import { description as homeDescription } from '@/constants/site'
 import { createMetadata, getBlogPageImage } from '@/lib/metadata'
@@ -46,9 +47,12 @@ export default async function Page(props: {
       <div className='flex flex-col gap-2'>
         <LLMCopyButtonWithViewOptions
           githubUrl={`https://github.com/${owner}/${repo}/blob/main/content/blog/${params.slug}.mdx`}
-          markdownUrl={`/blog.mdx/${params.slug}`}
+          markdownUrl={new URL(`/blog.mdx/${params.slug}`, baseUrl).toString()}
         />
-        <ShareMenu title={page.data.title ?? 'Untitled'} url={page.url} />
+        <ShareMenu
+          title={page.data.title ?? 'Untitled'}
+          url={new URL(page.url, baseUrl).toString()}
+        />
       </div>
     </>
   )

--- a/src/app/(home)/blog/page.tsx
+++ b/src/app/(home)/blog/page.tsx
@@ -8,6 +8,7 @@ import { SectionBody } from '@/components/section-body'
 import { Wrapper } from '@/components/wrapper'
 import { postsPerPage } from '@/constants/config'
 import { createMetadata } from '@/lib/metadata'
+import { parsePageParam } from '@/lib/pagination'
 import { getPostsByTag, getSortedByDatePosts, getTags } from '@/lib/source'
 import { Hero } from './_components/hero'
 import { NewsletterSection } from './_components/newsletter-section'
@@ -48,9 +49,7 @@ export default async function Page(props: {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }) {
   const searchParams = await props.searchParams
-  const pageIndex = searchParams.page
-    ? Number.parseInt(searchParams.page[0] ?? '', 10) - 1
-    : 0
+  const pageIndex = parsePageParam(searchParams.page) - 1
   if (pageIndex < 0 || pageIndex >= pageCount) {
     notFound()
   }
@@ -93,16 +92,7 @@ export default async function Page(props: {
   )
 }
 
-export const generateStaticParams = () => {
-  const slugs = Array.from({ length: pageCount }, (_, index) => ({
-    slug: [(index + 1).toString()],
-  }))
-
-  return [{ slug: [] }, ...slugs]
-}
-
 interface Props {
-  params: Promise<{ slug: string[] }>
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }
 
@@ -112,9 +102,11 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const searchParams = await props.searchParams
 
-  const pageIndex = searchParams.page
-    ? Number.parseInt(searchParams.page as string, 10)
-    : 1
+  const pageIndex = parsePageParam(searchParams.page)
+
+  if (pageIndex < 1 || pageIndex > pageCount) {
+    notFound()
+  }
 
   const isFirstPage = pageIndex === 1 || !searchParams.page
   const pageTitle = isFirstPage ? 'Posts' : `Posts - Page ${pageIndex}`

--- a/src/app/(home)/blog/tags/[...slug]/page.tsx
+++ b/src/app/(home)/blog/tags/[...slug]/page.tsx
@@ -10,6 +10,7 @@ import { HeroSection } from '@/components/sections/hero'
 import { ViewAnimation } from '@/components/view-animation'
 import { postsPerPage } from '@/constants/config'
 import { createMetadata } from '@/lib/metadata'
+import { parsePageParam } from '@/lib/pagination'
 import { getPostsByTag, getTags } from '@/lib/source'
 
 export const dynamicParams = false
@@ -97,9 +98,7 @@ export default async function Page(props: {
     return notFound()
   }
 
-  const pageIndex = searchParams.page
-    ? Number.parseInt(searchParams.page[0] ?? '', 10) - 1
-    : 0
+  const pageIndex = parsePageParam(searchParams.page) - 1
 
   if (pageIndex < 0 || pageIndex >= pageCount(tag)) {
     notFound()
@@ -144,14 +143,7 @@ export default async function Page(props: {
 
 export const generateStaticParams = () => {
   const tags = getTags()
-  return [
-    ...tags.map((tag) => ({ slug: [tag] })),
-    ...tags.flatMap((tag) =>
-      Array.from({ length: pageCount(tag) }, (_, index) => ({
-        slug: [tag, (index + 1).toString()],
-      }))
-    ),
-  ]
+  return tags.map((tag) => ({ slug: [tag] }))
 }
 
 interface Props {
@@ -167,9 +159,14 @@ export async function generateMetadata(
   const searchParams = await props.searchParams
 
   const tag = params.slug[0]
-  const pageIndex = searchParams.page
-    ? Number.parseInt(searchParams.page.toString(), 10)
-    : 1
+  if (!tag) {
+    notFound()
+  }
+  const pageIndex = parsePageParam(searchParams.page)
+
+  if (pageIndex < 1 || pageIndex > pageCount(tag)) {
+    notFound()
+  }
 
   const isFirstPage = pageIndex === 1 || !searchParams.page
   const pageTitle = isFirstPage

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,11 +1,10 @@
 import type { Metadata } from 'next'
-import { unstable_cache } from 'next/cache'
 import { ProfilePageJsonLd } from '@/components/json-ld'
-import type { Activity } from '@/components/kibo-ui/contribution-graph'
 import Separator from '@/components/separator'
 import { Wrapper } from '@/components/wrapper'
 import { testimonials } from '@/constants/portfolio/testimonials'
-import { baseOptions, description as homeDescription } from '@/constants/site'
+import { description as homeDescription } from '@/constants/site'
+import { getGitHubContributions } from '@/lib/github-contributions'
 import { createMetadata } from '@/lib/metadata'
 import { getSortedWork } from '@/lib/source'
 import About from './_components/about'
@@ -24,41 +23,9 @@ export const metadata: Metadata = createMetadata({
   twitter: { images: '/banner.png' },
 })
 
-const githubUrl = baseOptions.githubUrl ?? ''
-const githubUsername = githubUrl.split('/').filter(Boolean).at(-1)
-
-interface ContributionResponse {
-  contributions: Activity[]
-  total: Record<string, number>
-}
-
-const getCachedContributions = unstable_cache(
-  async () => {
-    if (!githubUsername) {
-      throw new Error('GitHub username is missing from baseOptions.')
-    }
-
-    const url = new URL(
-      `/v4/${githubUsername}?y=last`,
-      'https://github-contributions-api.jogruber.de'
-    )
-    const response = await fetch(url)
-
-    if (!response.ok) {
-      throw new Error('Failed to fetch GitHub contributions.')
-    }
-
-    const data = (await response.json()) as ContributionResponse
-
-    return data.contributions
-  },
-  ['github-contributions'],
-  { revalidate: 60 * 60 * 24 }
-)
-
 export default async function Home() {
   const works = getSortedWork().slice(0, 4)
-  const contributions = await getCachedContributions()
+  const contributions = getGitHubContributions()
 
   return (
     <>
@@ -73,7 +40,7 @@ export default async function Home() {
         <WorkPreview works={works} />
         <Testimonials testimonials={testimonials} />
         <Separator />
-        <Contributions data={contributions} />
+        <Contributions contributions={contributions} />
         <Separator />
         <CTA />
       </Wrapper>

--- a/src/app/(home)/work/[slug]/page.tsx
+++ b/src/app/(home)/work/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { TOCProvider } from 'fumadocs-ui/components/toc'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { type ReactElement, ViewTransition } from 'react'
@@ -114,7 +115,7 @@ export default async function Page(props: {
   const { body: Mdx, toc } = page.data
 
   return (
-    <>
+    <TOCProvider toc={toc}>
       <Header page={page} />
 
       <SectionBody className='flex'>
@@ -127,7 +128,7 @@ export default async function Page(props: {
         </article>
       </SectionBody>
       <WorkJsonLd page={page} />
-    </>
+    </TOCProvider>
   )
 }
 

--- a/src/app/(home)/work/[slug]/page.tsx
+++ b/src/app/(home)/work/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import { TOCProvider } from 'fumadocs-ui/components/toc'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { type ReactElement, ViewTransition } from 'react'
@@ -115,20 +114,20 @@ export default async function Page(props: {
   const { body: Mdx, toc } = page.data
 
   return (
-    <TOCProvider toc={toc}>
+    <>
       <Header page={page} />
 
       <SectionBody className='flex'>
-        <TOCMinimap />
+        <TOCMinimap items={toc} />
         <article className='flex min-h-full min-w-0 flex-1 flex-col'>
-          <TOCPopover />
+          <TOCPopover items={toc} />
           <div className='prose prose-zinc dark:prose-invert prose-content min-w-0 flex-1 p-4'>
             <Mdx components={{ ...mdxComponents, GitHubCode }} />
           </div>
         </article>
       </SectionBody>
       <WorkJsonLd page={page} />
-    </TOCProvider>
+    </>
   )
 }
 

--- a/src/app/(home)/work/page.tsx
+++ b/src/app/(home)/work/page.tsx
@@ -9,6 +9,7 @@ import { WorkCard } from '@/components/work/work-card'
 import { Wrapper } from '@/components/wrapper'
 import { worksPerPage } from '@/constants/config'
 import { createMetadata } from '@/lib/metadata'
+import { parsePageParam } from '@/lib/pagination'
 import { getSortedWork } from '@/lib/source'
 import { Hero } from './_components/hero'
 
@@ -39,9 +40,7 @@ export default async function Page(props: {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }) {
   const searchParams = await props.searchParams
-  const pageIndex = searchParams.page
-    ? Number.parseInt(searchParams.page[0] ?? '', 10) - 1
-    : 0
+  const pageIndex = parsePageParam(searchParams.page) - 1
 
   if (pageIndex < 0 || pageIndex >= pageCount) {
     notFound()
@@ -108,16 +107,7 @@ export default async function Page(props: {
   )
 }
 
-export const generateStaticParams = () => {
-  const slugs = Array.from({ length: pageCount }, (_, index) => ({
-    slug: [(index + 1).toString()],
-  }))
-
-  return [{ slug: [] }, ...slugs]
-}
-
 interface Props {
-  params: Promise<{ slug: string[] }>
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }
 
@@ -127,9 +117,11 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const searchParams = await props.searchParams
 
-  const pageIndex = searchParams.page
-    ? Number.parseInt(searchParams.page as string, 10)
-    : 1
+  const pageIndex = parsePageParam(searchParams.page)
+
+  if (pageIndex < 1 || pageIndex > pageCount) {
+    notFound()
+  }
 
   const isFirstPage = pageIndex === 1 || !searchParams.page
   const pageTitle = isFirstPage ? 'Work' : `Work - Page ${pageIndex}`

--- a/src/components/ai/page-actions.tsx
+++ b/src/components/ai/page-actions.tsx
@@ -40,6 +40,9 @@ function useMarkdownCopy(markdownUrl: string) {
         await navigator.clipboard.write([
           new ClipboardItem({
             'text/plain': fetch(markdownUrl).then(async (res) => {
+              if (!res.ok) {
+                throw new Error(`Failed to fetch markdown: ${res.status}`)
+              }
               const content = await res.text()
               cache.set(markdownUrl, content)
               return content
@@ -103,10 +106,7 @@ export function ViewOptions({
   disabled?: boolean
 }) {
   const items = useMemo(() => {
-    const fullMarkdownUrl =
-      typeof window === 'undefined'
-        ? 'loading'
-        : new URL(markdownUrl, window.location.origin).toString()
+    const fullMarkdownUrl = markdownUrl
 
     const q = `Read ${fullMarkdownUrl}, I want to ask questions about it.`
 

--- a/src/components/kibo-ui/contribution-graph/index.tsx
+++ b/src/components/kibo-ui/contribution-graph/index.tsx
@@ -357,10 +357,12 @@ export interface ContributionGraphCalendarProps
   }) => ReactNode
   className?: string
   hideMonthLabels?: boolean
+  title?: string
 }
 
 export const ContributionGraphCalendar = ({
   hideMonthLabels = false,
+  title = 'Contribution Graph',
   className,
   children,
   ...props
@@ -384,9 +386,12 @@ export const ContributionGraphCalendar = ({
         viewBox={`0 0 ${width} ${height}`}
         width={width}
       >
-        <title>Contribution Graph</title>
+        <title>{title}</title>
         {!hideMonthLabels && (
-          <g className='fill-current'>
+          <g
+            className='fill-current selection:fill-selection-foreground'
+            data-slot='month-labels'
+          >
             {monthLabels.map(({ label, weekIndex }) => (
               <text
                 dominantBaseline='hanging'

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -19,7 +19,7 @@ export function MobileNav() {
       <Presence present={menuOpen}>
         <button
           aria-label='Close menu'
-          className='fixed inset-0 z-[31] bg-background/50 data-[state=closed]:animate-fd-fade-out data-[state=open]:animate-fd-fade-in sm:hidden'
+          className='fixed inset-0 z-[31] bg-background/50 data-[state=closed]:animate-fd-fade-out data-[state=open]:animate-fd-fade-in lg:hidden'
           data-state={menuOpen ? 'open' : 'closed'}
           onClick={closeMenu}
           type='button'

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -2,24 +2,51 @@
 
 import { Presence } from '@radix-ui/react-presence'
 import { useSearchContext } from 'fumadocs-ui/contexts/search'
-import { useState } from 'react'
+import { usePathname } from 'next/navigation'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useAISearchContext } from '@/components/ai/chat'
 import { FloatingPill } from '@/components/mobile-nav/floating-pill'
 import { MenuPanel } from '@/components/mobile-nav/menu-panel'
 
 export function MobileNav() {
   const [menuOpen, setMenuOpen] = useState(false)
+  const pathname = usePathname()
+  const previousPathname = useRef(pathname)
   const { setOpenSearch } = useSearchContext()
   const { setOpen: setOpenAI } = useAISearchContext()
 
-  const closeMenu = () => setMenuOpen(false)
+  const closeMenu = useCallback(() => setMenuOpen(false), [])
+
+  useEffect(() => {
+    if (previousPathname.current === pathname) {
+      return
+    }
+
+    previousPathname.current = pathname
+    setMenuOpen(false)
+  }, [pathname])
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return
+    }
+
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeMenu()
+      }
+    }
+
+    document.addEventListener('keydown', closeOnEscape)
+    return () => document.removeEventListener('keydown', closeOnEscape)
+  }, [closeMenu, menuOpen])
 
   return (
     <>
       <Presence present={menuOpen}>
         <button
           aria-label='Close menu'
-          className='fixed inset-0 z-[31] bg-background/50 data-[state=closed]:animate-fd-fade-out data-[state=open]:animate-fd-fade-in lg:hidden'
+          className='fixed inset-0 z-[31] bg-background/50 data-[state=closed]:animate-fd-fade-out data-[state=open]:animate-fd-fade-in md:hidden'
           data-state={menuOpen ? 'open' : 'closed'}
           onClick={closeMenu}
           type='button'
@@ -28,6 +55,7 @@ export function MobileNav() {
 
       <Presence present={menuOpen}>
         <MenuPanel
+          menuId='mobile-navigation-menu'
           menuOpen={menuOpen}
           onAIChatOpen={() => {
             closeMenu()
@@ -38,6 +66,7 @@ export function MobileNav() {
       </Presence>
 
       <FloatingPill
+        menuId='mobile-navigation-menu'
         menuOpen={menuOpen}
         onMenuToggle={() => setMenuOpen((open) => !open)}
         onSearchOpen={() => {

--- a/src/components/mobile-nav/floating-pill.tsx
+++ b/src/components/mobile-nav/floating-pill.tsx
@@ -24,7 +24,7 @@ export function FloatingPill({
   ]
 
   return (
-    <div className='fixed inset-x-0 bottom-4 z-[32] flex justify-center sm:hidden'>
+    <div className='fixed inset-x-0 bottom-4 z-[32] flex justify-center lg:hidden'>
       <div className='flex items-center gap-0.5 rounded-full border bg-background/80 px-1.5 py-1.5 shadow-lg backdrop-blur-md'>
         <button
           aria-label='Search'

--- a/src/components/mobile-nav/floating-pill.tsx
+++ b/src/components/mobile-nav/floating-pill.tsx
@@ -6,10 +6,12 @@ import { cn } from '@/lib/utils'
 
 export function FloatingPill({
   menuOpen,
+  menuId,
   onMenuToggle,
   onSearchOpen,
 }: {
   menuOpen: boolean
+  menuId: string
   onMenuToggle: () => void
   onSearchOpen: () => void
 }) {
@@ -24,11 +26,11 @@ export function FloatingPill({
   ]
 
   return (
-    <div className='fixed inset-x-0 bottom-4 z-[32] flex justify-center lg:hidden'>
+    <div className='fixed inset-x-0 bottom-[calc(1rem+env(safe-area-inset-bottom))] z-[32] flex justify-center md:hidden'>
       <div className='flex items-center gap-0.5 rounded-full border bg-background/80 px-1.5 py-1.5 shadow-lg backdrop-blur-md'>
         <button
           aria-label='Search'
-          className='flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground'
+          className='flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50'
           onClick={onSearchOpen}
           type='button'
         >
@@ -50,9 +52,12 @@ export function FloatingPill({
         <div className='mx-1 h-4 w-px bg-border' />
 
         <button
+          aria-controls={menuId}
+          aria-expanded={menuOpen}
           aria-label='Toggle menu'
           className={cn(
             'relative flex size-8 items-center justify-center rounded-full transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
             menuOpen
               ? 'bg-primary/10 text-primary'
               : 'text-muted-foreground hover:text-foreground'

--- a/src/components/mobile-nav/menu-panel.tsx
+++ b/src/components/mobile-nav/menu-panel.tsx
@@ -38,7 +38,7 @@ export function MenuPanel({
   return (
     <div
       className={cn(
-        'fixed inset-x-4 bottom-20 z-[32] overflow-hidden rounded-xl border border-dashed bg-background sm:hidden',
+        'fixed inset-x-4 bottom-20 z-[32] overflow-hidden rounded-xl border border-dashed bg-background lg:hidden',
         menuOpen ? 'animate-fd-dialog-in' : 'animate-fd-dialog-out'
       )}
     >

--- a/src/components/mobile-nav/menu-panel.tsx
+++ b/src/components/mobile-nav/menu-panel.tsx
@@ -72,7 +72,7 @@ export function MenuPanel({
                   )}
                   href={item.url}
                   key={item.url}
-                  onClick={onClose}
+                  onClick={() => setTimeout(onClose, 0)}
                 >
                   {'icon' in item ? item.icon : null}
                   {item.text}

--- a/src/components/mobile-nav/menu-panel.tsx
+++ b/src/components/mobile-nav/menu-panel.tsx
@@ -10,10 +10,12 @@ import { cn } from '@/lib/utils'
 
 export function MenuPanel({
   menuOpen,
+  menuId,
   onAIChatOpen,
   onClose,
 }: {
   menuOpen: boolean
+  menuId: string
   onAIChatOpen: () => void
   onClose: () => void
 }) {
@@ -37,10 +39,14 @@ export function MenuPanel({
 
   return (
     <div
+      aria-label='Mobile navigation'
+      aria-modal='true'
       className={cn(
-        'fixed inset-x-4 bottom-20 z-[32] overflow-hidden rounded-xl border border-dashed bg-background lg:hidden',
+        'fixed inset-x-4 bottom-[calc(5rem+env(safe-area-inset-bottom))] z-[32] max-h-[calc(100dvh-7rem)] overflow-y-auto overscroll-contain rounded-xl border border-dashed bg-background md:hidden',
         menuOpen ? 'animate-fd-dialog-in' : 'animate-fd-dialog-out'
       )}
+      id={menuId}
+      role='dialog'
     >
       <nav className='flex flex-col divide-y divide-dashed divide-border'>
         {menuRows.map((row) => (

--- a/src/components/mobile-nav/nav-item.tsx
+++ b/src/components/mobile-nav/nav-item.tsx
@@ -24,7 +24,7 @@ export function NavItem({
       aria-current={active ? 'page' : undefined}
       aria-label={label}
       className={cn(
-        'flex size-8 items-center justify-center rounded-full transition-colors',
+        'flex size-8 items-center justify-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
         active
           ? 'bg-primary/10 text-primary'
           : 'text-muted-foreground hover:text-foreground'

--- a/src/components/sections/header/index.tsx
+++ b/src/components/sections/header/index.tsx
@@ -180,7 +180,7 @@ export const Header = ({
           </ViewAnimation>
         </div>
       </div>
-      <ul className='ms-auto -me-1.5 hidden flex-row items-center sm:flex lg:hidden'>
+      <ul className='ms-auto -me-1.5 hidden flex-row items-center md:flex lg:hidden'>
         {searchToggle.enabled !== false &&
           (searchToggle.components?.sm ?? (
             <ViewAnimation

--- a/src/components/sections/header/index.tsx
+++ b/src/components/sections/header/index.tsx
@@ -122,7 +122,7 @@ export const Header = ({
           </ViewAnimation>
           {nav.children}
         </div>
-        <ul className='absolute left-1/2 flex -translate-x-1/2 flex-row items-center gap-2 max-md:hidden'>
+        <ul className='absolute left-1/2 flex -translate-x-1/2 flex-row items-center gap-2 max-lg:hidden'>
           {navItems
             .filter((item) => !isSecondary(item))
             .map((item, i) => (
@@ -221,7 +221,7 @@ export const Header = ({
               .filter((item) => !isSecondary(item))
               .map((item, i) => (
                 <MobileNavigationMenuLinkItem
-                  className='sm:hidden'
+                  className='lg:hidden'
                   item={item}
                   key={i.toString()}
                 />

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -82,27 +82,123 @@ function TOCPopoverContent({ className }: { className?: string }) {
       </CollapsibleTrigger>
 
       <CollapsibleContent>
-        <ul className='flex max-h-[50vh] flex-col overflow-y-auto px-4 pb-2 md:px-6'>
-          {items.map((item) => (
-            <li className='flex py-1' key={item.id}>
-              <a
-                className={cn(
-                  'line-clamp-2 w-full text-muted-foreground text-sm transition-colors hover:text-foreground',
-                  item.active && 'text-foreground',
-                  'data-[depth=3]:pl-4 data-[depth=4]:pl-8'
-                )}
-                data-active={item.active}
-                data-depth={item.original.depth}
-                href={item.original.url}
-              >
-                {item.original.title}
-              </a>
-            </li>
-          ))}
-        </ul>
+        <TOCList items={items} />
       </CollapsibleContent>
     </Collapsible>
   )
+}
+
+function TOCList({ items }: { items: ReturnType<typeof useItems> }) {
+  return (
+    <ul className='flex max-h-[50vh] flex-col overflow-y-auto px-4 pb-2 md:px-6'>
+      {items.map((item, index) => {
+        const isFirst = index === 0
+        const isLast = index === items.length - 1
+        const currentLineOffset = getLineOffset(item.original.depth)
+        const previousLineOffset = isFirst
+          ? currentLineOffset
+          : getLineOffset(
+              items[index - 1]?.original.depth ?? item.original.depth
+            )
+        const nextLineOffset = isLast
+          ? currentLineOffset
+          : getLineOffset(
+              items[index + 1]?.original.depth ?? item.original.depth
+            )
+
+        return (
+          <li
+            className={cn(
+              'prose relative py-1.5 text-sm',
+              isFirst && 'pt-0',
+              isLast && 'pb-0'
+            )}
+            key={item.id}
+          >
+            <TOCTrack
+              currentLineOffset={currentLineOffset}
+              nextLineOffset={nextLineOffset}
+              previousLineOffset={previousLineOffset}
+            />
+            <a
+              className={cn(
+                'relative block scroll-m-4 text-muted-foreground transition-colors hover:text-foreground',
+                item.active && 'text-foreground'
+              )}
+              data-active={item.active}
+              data-depth={item.original.depth}
+              href={item.original.url}
+              style={{
+                paddingInlineStart: getItemOffset(item.original.depth),
+              }}
+            >
+              {item.original.title}
+            </a>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+function TOCTrack({
+  currentLineOffset,
+  nextLineOffset,
+  previousLineOffset,
+}: {
+  currentLineOffset: number
+  nextLineOffset: number
+  previousLineOffset: number
+}) {
+  return (
+    <svg
+      aria-hidden
+      className={cn(
+        'absolute inset-s-0 -top-1.5 bottom-0 -z-1 h-[calc(100%+--spacing(1.5))] rtl:-scale-x-100',
+        currentLineOffset !== nextLineOffset && 'bottom-1.5 h-full'
+      )}
+      style={{ width: Math.max(previousLineOffset, currentLineOffset) + 9 }}
+    >
+      {previousLineOffset !== currentLineOffset && (
+        <path
+          className='stroke-foreground/10'
+          d={`M ${previousLineOffset + 0.5} 0 C ${previousLineOffset + 0.5} 8 ${currentLineOffset + 0.5} 4 ${currentLineOffset + 0.5} 12`}
+          fill='none'
+          strokeWidth='1'
+        />
+      )}
+      <line
+        className='stroke-foreground/10'
+        strokeWidth='1'
+        x1={currentLineOffset + 0.5}
+        x2={currentLineOffset + 0.5}
+        y1={previousLineOffset === currentLineOffset ? '6' : '12'}
+        y2='100%'
+      />
+    </svg>
+  )
+}
+
+const BASE_LINE_OFFSET = 8
+
+function getItemOffset(depth: number) {
+  if (depth <= 2) {
+    return 12 + BASE_LINE_OFFSET
+  }
+  if (depth === 3) {
+    return 24 + BASE_LINE_OFFSET
+  }
+  return 36 + BASE_LINE_OFFSET
+}
+
+function getLineOffset(depth: number) {
+  if (depth <= 2) {
+    return BASE_LINE_OFFSET
+  }
+  if (depth === 3) {
+    return 8 + BASE_LINE_OFFSET
+  }
+  return 16 + BASE_LINE_OFFSET
 }
 
 function ProgressCircle({

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -1,42 +1,75 @@
 'use client'
 
-import type { Root as PageTreeRoot } from 'fumadocs-core/page-tree'
-import { useActiveAnchor, useTOCItems } from 'fumadocs-ui/components/toc'
-import { DocsLayout } from 'fumadocs-ui/layouts/docs'
-import { TOCPopover as FumaTOCPopover } from 'fumadocs-ui/layouts/docs/page/slots/toc'
+import type { TOCItemType } from 'fumadocs-core/toc'
+import { AnchorProvider, useActiveAnchor, useItems } from 'fumadocs-core/toc'
+import { TextIcon } from 'lucide-react'
+import { Icons } from '@/components/icons/icons'
 import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from '@/components/ui/hover-card'
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
 import { cn } from '@/lib/utils'
 
-const emptyTree: PageTreeRoot = { children: [], name: '' }
+export function TOCPopover({
+  className,
+  items,
+}: {
+  className?: string
+  items: TOCItemType[]
+}) {
+  if (!items.length) {
+    return null
+  }
 
-export function TOCPopover({ className }: { className?: string }) {
   return (
-    <DocsLayout
-      containerProps={{ style: { display: 'contents' } }}
-      nav={{ enabled: false }}
-      sidebar={{ enabled: false }}
-      tree={emptyTree}
-    >
-      <FumaTOCPopover
-        container={{
-          className: cn('top-14 h-10 xl:block 2xl:hidden', className),
-        }}
-      />
-    </DocsLayout>
+    <Collapsible className={cn('not-prose group/toc 2xl:hidden', className)}>
+      <CollapsibleTrigger className='inline-flex w-full items-center gap-2 border-border border-b py-2.5 pr-2 pl-4 text-muted-foreground text-sm outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 [&_svg]:size-4'>
+        <TextIcon className='-translate-x-0.5' />
+        On this page
+        <Icons.chevronDown className='ml-auto shrink-0 transition-transform duration-200 group-data-[state=open]/toc:rotate-180' />
+      </CollapsibleTrigger>
+
+      <CollapsibleContent>
+        <ul className='flex max-h-[50vh] flex-col overflow-y-auto px-4 pb-2'>
+          {items.map((item) => (
+            <li className='flex py-1' key={item.url}>
+              <a
+                className='text-muted-foreground text-sm transition-colors hover:text-foreground data-[depth=3]:pl-4 data-[depth=4]:pl-8'
+                data-depth={item.depth}
+                href={item.url}
+              >
+                {item.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </CollapsibleContent>
+    </Collapsible>
   )
 }
 
-export function TOCMinimap({ className }: { className?: string }) {
-  const items = useTOCItems()
-  const activeAnchor = useActiveAnchor()
-
-  if (items.length === 0) {
+export function TOCMinimap({
+  className,
+  items,
+}: {
+  className?: string
+  items: TOCItemType[]
+}) {
+  if (!items.length) {
     return null
   }
+
+  return (
+    <AnchorProvider toc={items}>
+      <TOCMinimapContent className={className} />
+    </AnchorProvider>
+  )
+}
+
+function TOCMinimapContent({ className }: { className?: string }) {
+  const items = useItems()
+  const activeAnchor = useActiveAnchor()
 
   return (
     <aside
@@ -44,47 +77,21 @@ export function TOCMinimap({ className }: { className?: string }) {
         'hidden w-[72px] shrink-0 2xl:absolute 2xl:inset-y-0 2xl:right-full 2xl:block',
         className
       )}
+      data-active-anchor={activeAnchor}
       data-toc-minimap=''
     >
       <div className='sticky top-14'>
-        <HoverCard closeDelay={100} openDelay={100}>
-          <HoverCardTrigger asChild>
-            <div className='flex max-h-[calc(100dvh-6rem)] flex-col gap-3 overflow-hidden pt-7 pb-3 pl-6'>
-              {items.map((item) => (
-                <div
-                  aria-hidden
-                  className='pointer-events-none h-0.5 w-6 shrink-0 rounded-xs bg-muted-foreground/50 transition-colors data-[depth=3]:ml-2 data-[depth=4]:ml-4 data-[depth=3]:w-4 data-[depth=4]:w-2 data-[active=true]:bg-foreground'
-                  data-active={item.url === `#${activeAnchor}`}
-                  data-depth={item.depth}
-                  key={item.url}
-                />
-              ))}
-            </div>
-          </HoverCardTrigger>
-
-          <HoverCardContent
-            align='start'
-            alignOffset={16}
-            className='w-56 overflow-hidden p-0'
-            side='left'
-            sideOffset={-60}
-          >
-            <ul className='flex max-h-[calc(100dvh-6rem)] w-full flex-col overflow-y-auto px-6 py-4 text-sm'>
-              {items.map((item) => (
-                <li className='flex py-1' key={item.url}>
-                  <a
-                    className='line-clamp-2 w-full text-muted-foreground transition-colors hover:text-foreground data-[depth=3]:pl-4 data-[depth=4]:pl-8 data-[active=true]:text-foreground'
-                    data-active={item.url === `#${activeAnchor}`}
-                    data-depth={item.depth}
-                    href={item.url}
-                  >
-                    {item.title}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </HoverCardContent>
-        </HoverCard>
+        <div className='flex max-h-[calc(100dvh-6rem)] flex-col gap-3 overflow-hidden pt-7 pb-3 pl-6'>
+          {items.map((item) => (
+            <div
+              aria-hidden
+              className='pointer-events-none h-0.5 w-6 shrink-0 rounded-xs bg-muted-foreground/50 transition-colors data-[depth=3]:ml-2 data-[depth=4]:ml-4 data-[depth=3]:w-4 data-[depth=4]:w-2 data-[active=true]:bg-foreground'
+              data-active={item.active}
+              data-depth={item.original.depth}
+              key={item.id}
+            />
+          ))}
+        </div>
       </div>
     </aside>
   )

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -2,7 +2,7 @@
 
 import type { TOCItemType } from 'fumadocs-core/toc'
 import { AnchorProvider, useActiveAnchor, useItems } from 'fumadocs-core/toc'
-import { TextIcon } from 'lucide-react'
+import { useState } from 'react'
 import { Icons } from '@/components/icons/icons'
 import {
   Collapsible,
@@ -23,29 +23,135 @@ export function TOCPopover({
   }
 
   return (
-    <Collapsible className={cn('not-prose group/toc 2xl:hidden', className)}>
-      <CollapsibleTrigger className='inline-flex w-full items-center gap-2 border-border border-b py-2.5 pr-2 pl-4 text-muted-foreground text-sm outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 [&_svg]:size-4'>
-        <TextIcon className='-translate-x-0.5' />
-        On this page
-        <Icons.chevronDown className='ml-auto shrink-0 transition-transform duration-200 group-data-[state=open]/toc:rotate-180' />
+    <AnchorProvider toc={items}>
+      <TOCPopoverContent className={className} />
+    </AnchorProvider>
+  )
+}
+
+function TOCPopoverContent({ className }: { className?: string }) {
+  const items = useItems()
+  const [open, setOpen] = useState(false)
+  const selectedIndex = items.findIndex((item) => item.active)
+  const showSelectedItem = selectedIndex !== -1 && !open
+
+  return (
+    <Collapsible
+      className={cn(
+        'not-prose sticky top-14 z-10 border-border border-b bg-background/80 backdrop-blur-sm xl:hidden',
+        className
+      )}
+      onOpenChange={setOpen}
+      open={open}
+    >
+      <CollapsibleTrigger className='flex h-10 w-full items-center gap-2.5 px-4 py-2.5 text-left text-muted-foreground text-sm outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 md:px-6 [&_svg]:size-4'>
+        <ProgressCircle
+          className={cn('shrink-0', open && 'text-foreground')}
+          value={
+            (items.findLastIndex((item) => item.active) + 1) /
+            Math.max(1, items.length)
+          }
+        />
+        <span className='grid min-w-0 flex-1 *:col-start-1 *:row-start-1'>
+          <span
+            className={cn(
+              'truncate transition-[opacity,translate,color]',
+              open && 'text-foreground',
+              showSelectedItem &&
+                'pointer-events-none -translate-y-full opacity-0'
+            )}
+          >
+            On this page
+          </span>
+          <span
+            className={cn(
+              'truncate transition-[opacity,translate]',
+              !showSelectedItem &&
+                'pointer-events-none translate-y-full opacity-0'
+            )}
+          >
+            {items[selectedIndex]?.original.title}
+          </span>
+        </span>
+        <Icons.chevronDown
+          className={cn(
+            'mx-0.5 shrink-0 transition-transform',
+            open && 'rotate-180'
+          )}
+        />
       </CollapsibleTrigger>
 
       <CollapsibleContent>
-        <ul className='flex max-h-[50vh] flex-col overflow-y-auto px-4 pb-2'>
+        <ul className='flex max-h-[50vh] flex-col overflow-y-auto px-4 pb-2 md:px-6'>
           {items.map((item) => (
-            <li className='flex py-1' key={item.url}>
+            <li className='flex py-1' key={item.id}>
               <a
-                className='text-muted-foreground text-sm transition-colors hover:text-foreground data-[depth=3]:pl-4 data-[depth=4]:pl-8'
-                data-depth={item.depth}
-                href={item.url}
+                className={cn(
+                  'line-clamp-2 w-full text-muted-foreground text-sm transition-colors hover:text-foreground',
+                  item.active && 'text-foreground',
+                  'data-[depth=3]:pl-4 data-[depth=4]:pl-8'
+                )}
+                data-active={item.active}
+                data-depth={item.original.depth}
+                href={item.original.url}
               >
-                {item.title}
+                {item.original.title}
               </a>
             </li>
           ))}
         </ul>
       </CollapsibleContent>
     </Collapsible>
+  )
+}
+
+function ProgressCircle({
+  className,
+  value,
+}: {
+  className?: string
+  value: number
+}) {
+  const size = 18
+  const strokeWidth = 1.5
+  const radius = size / 2 - strokeWidth
+  const circumference = 2 * Math.PI * radius
+  const progress = Math.min(1, Math.max(0, value)) * circumference
+
+  return (
+    <svg
+      aria-label='Table of contents progress'
+      aria-valuemax={1}
+      aria-valuemin={0}
+      aria-valuenow={Math.min(1, Math.max(0, value))}
+      className={className}
+      height={size}
+      role='progressbar'
+      viewBox={`0 0 ${size} ${size}`}
+      width={size}
+    >
+      <circle
+        className='stroke-current/25'
+        cx={size / 2}
+        cy={size / 2}
+        fill='none'
+        r={radius}
+        strokeWidth={strokeWidth}
+      />
+      <circle
+        className='transition-all'
+        cx={size / 2}
+        cy={size / 2}
+        fill='none'
+        r={radius}
+        stroke='currentColor'
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference - progress}
+        strokeLinecap='round'
+        strokeWidth={strokeWidth}
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+      />
+    </svg>
   )
 }
 

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -38,7 +38,7 @@ function TOCPopoverContent({ className }: { className?: string }) {
   return (
     <Collapsible
       className={cn(
-        'not-prose sticky top-14 z-10 border-border border-b bg-background/80 backdrop-blur-sm xl:hidden',
+        'not-prose sticky top-14 z-10 border-border border-b bg-background/80 backdrop-blur-sm xl:block 2xl:hidden',
         className
       )}
       onOpenChange={setOpen}

--- a/src/components/toc.tsx
+++ b/src/components/toc.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import type { TOCItemType } from 'fumadocs-core/toc'
-import { AnchorProvider, useActiveAnchor, useItems } from 'fumadocs-core/toc'
+import { useActiveAnchor, useItems } from 'fumadocs-ui/components/toc'
+import { TOCItem, TOCItems } from 'fumadocs-ui/components/toc/default'
 import { useState } from 'react'
 import { Icons } from '@/components/icons/icons'
 import {
@@ -22,11 +23,7 @@ export function TOCPopover({
     return null
   }
 
-  return (
-    <AnchorProvider toc={items}>
-      <TOCPopoverContent className={className} />
-    </AnchorProvider>
-  )
+  return <TOCPopoverContent className={className} />
 }
 
 function TOCPopoverContent({ className }: { className?: string }) {
@@ -82,123 +79,22 @@ function TOCPopoverContent({ className }: { className?: string }) {
       </CollapsibleTrigger>
 
       <CollapsibleContent>
-        <TOCList items={items} />
+        <TOCItems className='max-h-[50vh] overflow-y-auto px-4 pb-2 md:px-6'>
+          {items.map((item) => (
+            <TOCItem
+              className={cn(
+                'text-muted-foreground hover:text-foreground',
+                item.active && 'text-foreground'
+              )}
+              item={item.original}
+              key={item.id}
+              onClick={() => setOpen(false)}
+            />
+          ))}
+        </TOCItems>
       </CollapsibleContent>
     </Collapsible>
   )
-}
-
-function TOCList({ items }: { items: ReturnType<typeof useItems> }) {
-  return (
-    <ul className='flex max-h-[50vh] flex-col overflow-y-auto px-4 pb-2 md:px-6'>
-      {items.map((item, index) => {
-        const isFirst = index === 0
-        const isLast = index === items.length - 1
-        const currentLineOffset = getLineOffset(item.original.depth)
-        const previousLineOffset = isFirst
-          ? currentLineOffset
-          : getLineOffset(
-              items[index - 1]?.original.depth ?? item.original.depth
-            )
-        const nextLineOffset = isLast
-          ? currentLineOffset
-          : getLineOffset(
-              items[index + 1]?.original.depth ?? item.original.depth
-            )
-
-        return (
-          <li
-            className={cn(
-              'prose relative py-1.5 text-sm',
-              isFirst && 'pt-0',
-              isLast && 'pb-0'
-            )}
-            key={item.id}
-          >
-            <TOCTrack
-              currentLineOffset={currentLineOffset}
-              nextLineOffset={nextLineOffset}
-              previousLineOffset={previousLineOffset}
-            />
-            <a
-              className={cn(
-                'relative block scroll-m-4 text-muted-foreground transition-colors hover:text-foreground',
-                item.active && 'text-foreground'
-              )}
-              data-active={item.active}
-              data-depth={item.original.depth}
-              href={item.original.url}
-              style={{
-                paddingInlineStart: getItemOffset(item.original.depth),
-              }}
-            >
-              {item.original.title}
-            </a>
-          </li>
-        )
-      })}
-    </ul>
-  )
-}
-
-function TOCTrack({
-  currentLineOffset,
-  nextLineOffset,
-  previousLineOffset,
-}: {
-  currentLineOffset: number
-  nextLineOffset: number
-  previousLineOffset: number
-}) {
-  return (
-    <svg
-      aria-hidden
-      className={cn(
-        'absolute inset-s-0 -top-1.5 bottom-0 -z-1 h-[calc(100%+--spacing(1.5))] rtl:-scale-x-100',
-        currentLineOffset !== nextLineOffset && 'bottom-1.5 h-full'
-      )}
-      style={{ width: Math.max(previousLineOffset, currentLineOffset) + 9 }}
-    >
-      {previousLineOffset !== currentLineOffset && (
-        <path
-          className='stroke-foreground/10'
-          d={`M ${previousLineOffset + 0.5} 0 C ${previousLineOffset + 0.5} 8 ${currentLineOffset + 0.5} 4 ${currentLineOffset + 0.5} 12`}
-          fill='none'
-          strokeWidth='1'
-        />
-      )}
-      <line
-        className='stroke-foreground/10'
-        strokeWidth='1'
-        x1={currentLineOffset + 0.5}
-        x2={currentLineOffset + 0.5}
-        y1={previousLineOffset === currentLineOffset ? '6' : '12'}
-        y2='100%'
-      />
-    </svg>
-  )
-}
-
-const BASE_LINE_OFFSET = 8
-
-function getItemOffset(depth: number) {
-  if (depth <= 2) {
-    return 12 + BASE_LINE_OFFSET
-  }
-  if (depth === 3) {
-    return 24 + BASE_LINE_OFFSET
-  }
-  return 36 + BASE_LINE_OFFSET
-}
-
-function getLineOffset(depth: number) {
-  if (depth <= 2) {
-    return BASE_LINE_OFFSET
-  }
-  if (depth === 3) {
-    return 8 + BASE_LINE_OFFSET
-  }
-  return 16 + BASE_LINE_OFFSET
 }
 
 function ProgressCircle({
@@ -262,11 +158,7 @@ export function TOCMinimap({
     return null
   }
 
-  return (
-    <AnchorProvider toc={items}>
-      <TOCMinimapContent className={className} />
-    </AnchorProvider>
-  )
+  return <TOCMinimapContent className={className} />
 }
 
 function TOCMinimapContent({ className }: { className?: string }) {

--- a/src/components/toc/index.tsx
+++ b/src/components/toc/index.tsx
@@ -1,0 +1,2 @@
+export { TOCMinimap } from './minimap'
+export { TOCPopover } from './popover'

--- a/src/components/toc/minimap.tsx
+++ b/src/components/toc/minimap.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import type { TOCItemType } from 'fumadocs-core/toc'
+import { useActiveAnchor, useItems } from 'fumadocs-ui/components/toc'
+import { cn } from '@/lib/utils'
+
+export function TOCMinimap({
+  className,
+  items,
+}: {
+  className?: string
+  items: TOCItemType[]
+}) {
+  if (!items.length) {
+    return null
+  }
+
+  return <TOCMinimapContent className={className} />
+}
+
+function TOCMinimapContent({ className }: { className?: string }) {
+  const items = useItems()
+  const activeAnchor = useActiveAnchor()
+
+  return (
+    <aside
+      className={cn(
+        'hidden w-[72px] shrink-0 2xl:absolute 2xl:inset-y-0 2xl:right-full 2xl:block',
+        className
+      )}
+      data-active-anchor={activeAnchor}
+      data-toc-minimap=''
+    >
+      <div className='sticky top-14'>
+        <div className='flex max-h-[calc(100dvh-6rem)] flex-col gap-3 overflow-hidden pt-7 pb-3 pl-6'>
+          {items.map((item) => (
+            <div
+              aria-hidden
+              className='pointer-events-none h-0.5 w-6 shrink-0 rounded-xs bg-muted-foreground/50 transition-colors data-[depth=3]:ml-2 data-[depth=4]:ml-4 data-[depth=3]:w-4 data-[depth=4]:w-2 data-[active=true]:bg-foreground'
+              data-active={item.active}
+              data-depth={item.original.depth}
+              key={item.id}
+            />
+          ))}
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/src/components/toc/minimap.tsx
+++ b/src/components/toc/minimap.tsx
@@ -39,7 +39,11 @@ function TOCMinimapContent({ className }: { className?: string }) {
       <div className='sticky top-14'>
         <HoverCard closeDelay={100} openDelay={100}>
           <HoverCardTrigger asChild>
-            <div className='flex max-h-[calc(100dvh-6rem)] flex-col gap-3 overflow-hidden pt-7 pb-3 pl-6'>
+            <button
+              aria-label='Open table of contents'
+              className='flex max-h-[calc(100dvh-6rem)] flex-col gap-3 overflow-hidden pt-7 pb-3 pl-6 outline-none focus-visible:ring-2 focus-visible:ring-ring/50'
+              type='button'
+            >
               {items.map((item) => (
                 <div
                   aria-hidden
@@ -49,7 +53,7 @@ function TOCMinimapContent({ className }: { className?: string }) {
                   key={item.id}
                 />
               ))}
-            </div>
+            </button>
           </HoverCardTrigger>
 
           <HoverCardContent

--- a/src/components/toc/minimap.tsx
+++ b/src/components/toc/minimap.tsx
@@ -43,7 +43,7 @@ function TOCMinimapContent({ className }: { className?: string }) {
               {items.map((item) => (
                 <div
                   aria-hidden
-                  className='pointer-events-none h-0.5 w-6 shrink-0 rounded-xs bg-muted-foreground/50 transition-colors data-[depth=3]:ml-2 data-[depth=4]:ml-4 data-[depth=3]:w-4 data-[depth=4]:w-2 data-[active=true]:bg-foreground'
+                  className='pointer-events-none h-0.5 w-6 shrink-0 rounded-xs bg-muted-foreground/50 transition-colors data-[depth=3]:ml-2 data-[depth=4]:ml-4 data-[depth=3]:w-4 data-[depth=4]:w-2 data-[active=true]:bg-fd-primary'
                   data-active={item.active}
                   data-depth={item.original.depth}
                   key={item.id}
@@ -63,7 +63,7 @@ function TOCMinimapContent({ className }: { className?: string }) {
               {items.map((item) => (
                 <li className='flex py-1' key={item.id}>
                   <a
-                    className='line-clamp-2 w-full text-muted-foreground transition-colors hover:text-foreground data-active:text-foreground'
+                    className='line-clamp-2 w-full text-muted-foreground transition-colors hover:text-foreground data-active:text-fd-primary'
                     data-active={item.active}
                     data-depth={item.original.depth}
                     href={item.original.url}

--- a/src/components/toc/minimap.tsx
+++ b/src/components/toc/minimap.tsx
@@ -2,6 +2,11 @@
 
 import type { TOCItemType } from 'fumadocs-core/toc'
 import { useActiveAnchor, useItems } from 'fumadocs-ui/components/toc'
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@/components/ui/hover-card'
 import { cn } from '@/lib/utils'
 
 export function TOCMinimap({
@@ -32,17 +37,44 @@ function TOCMinimapContent({ className }: { className?: string }) {
       data-toc-minimap=''
     >
       <div className='sticky top-14'>
-        <div className='flex max-h-[calc(100dvh-6rem)] flex-col gap-3 overflow-hidden pt-7 pb-3 pl-6'>
-          {items.map((item) => (
-            <div
-              aria-hidden
-              className='pointer-events-none h-0.5 w-6 shrink-0 rounded-xs bg-muted-foreground/50 transition-colors data-[depth=3]:ml-2 data-[depth=4]:ml-4 data-[depth=3]:w-4 data-[depth=4]:w-2 data-[active=true]:bg-foreground'
-              data-active={item.active}
-              data-depth={item.original.depth}
-              key={item.id}
-            />
-          ))}
-        </div>
+        <HoverCard closeDelay={100} openDelay={100}>
+          <HoverCardTrigger asChild>
+            <div className='flex max-h-[calc(100dvh-6rem)] flex-col gap-3 overflow-hidden pt-7 pb-3 pl-6'>
+              {items.map((item) => (
+                <div
+                  aria-hidden
+                  className='pointer-events-none h-0.5 w-6 shrink-0 rounded-xs bg-muted-foreground/50 transition-colors data-[depth=3]:ml-2 data-[depth=4]:ml-4 data-[depth=3]:w-4 data-[depth=4]:w-2 data-[active=true]:bg-foreground'
+                  data-active={item.active}
+                  data-depth={item.original.depth}
+                  key={item.id}
+                />
+              ))}
+            </div>
+          </HoverCardTrigger>
+
+          <HoverCardContent
+            align='start'
+            alignOffset={16}
+            className='w-56 overflow-hidden p-0'
+            side='left'
+            sideOffset={-60}
+          >
+            <ul className='flex max-h-[calc(100dvh-6rem)] w-full flex-col overflow-y-auto px-6 py-4 text-sm'>
+              {items.map((item) => (
+                <li className='flex py-1' key={item.id}>
+                  <a
+                    className='line-clamp-2 w-full text-muted-foreground transition-colors hover:text-foreground data-active:text-foreground'
+                    data-active={item.active}
+                    data-depth={item.original.depth}
+                    href={item.original.url}
+                  >
+                    {item.original.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </HoverCardContent>
+        </HoverCard>
       </div>
     </aside>
   )

--- a/src/components/toc/popover.tsx
+++ b/src/components/toc/popover.tsx
@@ -43,7 +43,7 @@ function TOCPopoverContent({ className }: { className?: string }) {
     >
       <CollapsibleTrigger className='flex h-10 w-full items-center gap-2.5 px-4 py-2.5 text-left text-muted-foreground text-sm outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 md:px-6 [&_svg]:size-4'>
         <ProgressCircle
-          className={cn('shrink-0', open && 'text-foreground')}
+          className={cn('shrink-0', open && 'text-fd-primary')}
           value={
             (items.findLastIndex((item) => item.active) + 1) /
             Math.max(1, items.length)
@@ -85,7 +85,7 @@ function TOCPopoverContent({ className }: { className?: string }) {
               <TOCItem
                 className={cn(
                   'text-muted-foreground hover:text-foreground',
-                  item.active && 'text-foreground'
+                  item.active && 'text-fd-primary'
                 )}
                 item={item.original}
                 key={item.id}

--- a/src/components/toc/popover.tsx
+++ b/src/components/toc/popover.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import type { TOCItemType } from 'fumadocs-core/toc'
-import { useItems } from 'fumadocs-ui/components/toc'
+import { TOCScrollArea, useItems } from 'fumadocs-ui/components/toc'
 import { TOCItem, TOCItems } from 'fumadocs-ui/components/toc/default'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Icons } from '@/components/icons/icons'
 import {
   Collapsible,
@@ -28,73 +28,96 @@ export function TOCPopover({
 
 function TOCPopoverContent({ className }: { className?: string }) {
   const items = useItems()
+  const ref = useRef<HTMLElement>(null)
   const [open, setOpen] = useState(false)
   const selectedIndex = items.findIndex((item) => item.active)
   const showSelectedItem = selectedIndex !== -1 && !open
 
+  useEffect(() => {
+    const onClickOutside = (event: MouseEvent) => {
+      if (!(open && event.target instanceof HTMLElement)) {
+        return
+      }
+
+      if (ref.current && !ref.current.contains(event.target)) {
+        setOpen(false)
+      }
+    }
+
+    window.addEventListener('click', onClickOutside)
+    return () => window.removeEventListener('click', onClickOutside)
+  }, [open])
+
   return (
     <Collapsible
       className={cn(
-        'not-prose sticky top-14 z-10 border-border border-b bg-background/80 backdrop-blur-sm xl:block 2xl:hidden',
+        'not-prose sticky top-14 z-10 xl:block 2xl:hidden',
         className
       )}
+      data-toc-popover=''
       onOpenChange={setOpen}
       open={open}
     >
-      <CollapsibleTrigger className='flex h-10 w-full items-center gap-2.5 px-4 py-2.5 text-left text-muted-foreground text-sm outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 md:px-6 [&_svg]:size-4'>
-        <ProgressCircle
-          className={cn('shrink-0', open && 'text-fd-primary')}
-          value={
-            (items.findLastIndex((item) => item.active) + 1) /
-            Math.max(1, items.length)
-          }
-        />
-        <span className='grid min-w-0 flex-1 *:col-start-1 *:row-start-1'>
-          <span
-            className={cn(
-              'truncate transition-[opacity,translate,color]',
-              open && 'text-foreground',
-              showSelectedItem &&
-                'pointer-events-none -translate-y-full opacity-0'
-            )}
-          >
-            On this page
+      <header
+        className={cn(
+          'border-b backdrop-blur-sm transition-colors',
+          open && 'bg-fd-background/80 shadow-lg'
+        )}
+        ref={ref}
+      >
+        <CollapsibleTrigger className='flex h-10 w-full items-center gap-2.5 px-4 py-2.5 text-start text-fd-muted-foreground text-sm focus-visible:outline-none md:px-6 [&_svg]:size-4'>
+          <ProgressCircle
+            className={cn('shrink-0', open && 'text-fd-primary')}
+            value={
+              (items.findLastIndex((item) => item.active) + 1) /
+              Math.max(1, items.length)
+            }
+          />
+          <span className='grid min-w-0 flex-1 *:col-start-1 *:row-start-1'>
+            <span
+              className={cn(
+                'truncate transition-[opacity,translate,color]',
+                open && 'text-fd-foreground',
+                showSelectedItem &&
+                  'pointer-events-none -translate-y-full opacity-0'
+              )}
+            >
+              On this page
+            </span>
+            <span
+              className={cn(
+                'truncate transition-[opacity,translate]',
+                !showSelectedItem &&
+                  'pointer-events-none translate-y-full opacity-0'
+              )}
+            >
+              {items[selectedIndex]?.original.title}
+            </span>
           </span>
-          <span
+          <Icons.chevronDown
             className={cn(
-              'truncate transition-[opacity,translate]',
-              !showSelectedItem &&
-                'pointer-events-none translate-y-full opacity-0'
+              'mx-0.5 shrink-0 transition-transform',
+              open && 'rotate-180'
             )}
-          >
-            {items[selectedIndex]?.original.title}
-          </span>
-        </span>
-        <Icons.chevronDown
-          className={cn(
-            'mx-0.5 shrink-0 transition-transform',
-            open && 'rotate-180'
-          )}
-        />
-      </CollapsibleTrigger>
+          />
+        </CollapsibleTrigger>
 
-      <CollapsibleContent>
-        <div className='flex max-h-[50vh] flex-col overflow-y-auto px-4 pb-2 md:px-6'>
-          <TOCItems>
-            {items.map((item) => (
-              <TOCItem
-                className={cn(
-                  'text-muted-foreground hover:text-foreground',
-                  item.active && 'text-fd-primary'
-                )}
-                item={item.original}
-                key={item.id}
-                onClick={() => setOpen(false)}
-              />
-            ))}
-          </TOCItems>
-        </div>
-      </CollapsibleContent>
+        <CollapsibleContent>
+          <div className='flex max-h-[50vh] flex-col px-4 md:px-6'>
+            <TOCScrollArea>
+              <TOCItems>
+                {items.map((item) => (
+                  <TOCItem
+                    item={item.original}
+                    key={item.id}
+                    onClick={() => setOpen(false)}
+                  />
+                ))}
+              </TOCItems>
+            </TOCScrollArea>
+          </div>
+        </CollapsibleContent>
+      </header>
     </Collapsible>
   )
 }

--- a/src/components/toc/popover.tsx
+++ b/src/components/toc/popover.tsx
@@ -79,19 +79,21 @@ function TOCPopoverContent({ className }: { className?: string }) {
       </CollapsibleTrigger>
 
       <CollapsibleContent>
-        <TOCItems className='max-h-[50vh] overflow-y-auto px-4 pb-2 md:px-6'>
-          {items.map((item) => (
-            <TOCItem
-              className={cn(
-                'text-muted-foreground hover:text-foreground',
-                item.active && 'text-foreground'
-              )}
-              item={item.original}
-              key={item.id}
-              onClick={() => setOpen(false)}
-            />
-          ))}
-        </TOCItems>
+        <div className='flex max-h-[50vh] flex-col overflow-y-auto px-4 pb-2 md:px-6'>
+          <TOCItems>
+            {items.map((item) => (
+              <TOCItem
+                className={cn(
+                  'text-muted-foreground hover:text-foreground',
+                  item.active && 'text-foreground'
+                )}
+                item={item.original}
+                key={item.id}
+                onClick={() => setOpen(false)}
+              />
+            ))}
+          </TOCItems>
+        </div>
       </CollapsibleContent>
     </Collapsible>
   )

--- a/src/components/toc/popover.tsx
+++ b/src/components/toc/popover.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { TOCItemType } from 'fumadocs-core/toc'
-import { useActiveAnchor, useItems } from 'fumadocs-ui/components/toc'
+import { useItems } from 'fumadocs-ui/components/toc'
 import { TOCItem, TOCItems } from 'fumadocs-ui/components/toc/default'
 import { useState } from 'react'
 import { Icons } from '@/components/icons/icons'
@@ -144,49 +144,5 @@ function ProgressCircle({
         transform={`rotate(-90 ${size / 2} ${size / 2})`}
       />
     </svg>
-  )
-}
-
-export function TOCMinimap({
-  className,
-  items,
-}: {
-  className?: string
-  items: TOCItemType[]
-}) {
-  if (!items.length) {
-    return null
-  }
-
-  return <TOCMinimapContent className={className} />
-}
-
-function TOCMinimapContent({ className }: { className?: string }) {
-  const items = useItems()
-  const activeAnchor = useActiveAnchor()
-
-  return (
-    <aside
-      className={cn(
-        'hidden w-[72px] shrink-0 2xl:absolute 2xl:inset-y-0 2xl:right-full 2xl:block',
-        className
-      )}
-      data-active-anchor={activeAnchor}
-      data-toc-minimap=''
-    >
-      <div className='sticky top-14'>
-        <div className='flex max-h-[calc(100dvh-6rem)] flex-col gap-3 overflow-hidden pt-7 pb-3 pl-6'>
-          {items.map((item) => (
-            <div
-              aria-hidden
-              className='pointer-events-none h-0.5 w-6 shrink-0 rounded-xs bg-muted-foreground/50 transition-colors data-[depth=3]:ml-2 data-[depth=4]:ml-4 data-[depth=3]:w-4 data-[depth=4]:w-2 data-[active=true]:bg-foreground'
-              data-active={item.active}
-              data-depth={item.original.depth}
-              key={item.id}
-            />
-          ))}
-        </div>
-      </div>
-    </aside>
   )
 }

--- a/src/lib/github-contributions.ts
+++ b/src/lib/github-contributions.ts
@@ -1,0 +1,36 @@
+import 'server-only'
+
+import { unstable_cache } from 'next/cache'
+import type { Activity } from '@/components/kibo-ui/contribution-graph'
+import { baseOptions } from '@/constants/site'
+
+interface ContributionResponse {
+  contributions: Activity[]
+}
+
+const githubUsername = baseOptions.githubUrl?.split('/').filter(Boolean).at(-1)
+
+export const getGitHubContributions = unstable_cache(
+  async () => {
+    if (!githubUsername) {
+      return []
+    }
+
+    const url = new URL(
+      `/v4/${githubUsername}?y=last`,
+      process.env.GITHUB_CONTRIBUTIONS_API_URL ||
+        'https://github-contributions-api.jogruber.de'
+    )
+    const response = await fetch(url)
+
+    if (!response.ok) {
+      return []
+    }
+
+    const data = (await response.json()) as ContributionResponse
+
+    return data.contributions ?? []
+  },
+  ['github-contributions', githubUsername ?? 'unknown'],
+  { revalidate: 60 * 60 * 24 }
+)

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,16 @@
+const PAGE_PATTERN = /^\d+$/
+
+export function parsePageParam(value: string | string[] | undefined): number {
+  const raw = Array.isArray(value) ? value[0] : value
+
+  if (raw === undefined) {
+    return 1
+  }
+
+  if (!(raw && PAGE_PATTERN.test(raw))) {
+    return 0
+  }
+
+  const page = Number(raw)
+  return Number.isSafeInteger(page) && page > 0 ? page : 0
+}


### PR DESCRIPTION
## Summary

- load GitHub contribution data through a cached Promise and React `use()` + `Suspense`
- preserve the portfolio's responsive sizing, GitHub-green colors, tooltip styling, and custom legend
- add graph/calendar accessibility annotations and correct singular/plural tooltip text
- describe totals as the past 365 days and handle unavailable contribution data gracefully
- use Fumadocs' public TOC primitives for the active heading track and colored progress line
- provide a custom mobile TOC trigger and restore the interactive minimap hover card
- keep TOC controls hidden when a page has no headings

## Verification

- `bun run check`
- `SKIP_ENV_VALIDATION=true bun run typecheck`
- local homepage and heading-rich article rendered successfully
- heading-less article rendered without TOC controls

`useActiveHeading` was left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added responsive table-of-contents minimap and popover navigation for articles and work pages.
  - Added contribution graph loading states, localized activity totals, and improved accessibility labels.

- **Bug Fixes**
  - Improved mobile navigation behavior, including closing on route changes and Escape.
  - Corrected sharing, clipboard, and markdown URL handling.
  - Invalid blog, tag, and work page numbers now display proper not-found pages.

- **Accessibility & UX**
  - Added keyboard focus indicators, menu semantics, responsive safe-area spacing, and clearer navigation controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->