### PR TITLE
Add account actions to command palette and mobile menu

### DIFF
--- a/src/components/features/search/dialog.tsx
+++ b/src/components/features/search/dialog.tsx
@@ -34,6 +34,7 @@ import {
 import { usePages } from '@/contexts/pages'
 import { click, collapse, keyPress, notification } from '@/lib/audio/minimal'
 import { getLoginUrl, signOut, useSession } from '@/lib/auth-client'
+import type { CommandItem as SearchCommandItem } from '@/types/search'
 
 const NAV_SOUND_THROTTLE_MS = 60
 
@@ -62,9 +63,40 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
   const { data: sessionData } = useSession()
   const user = sessionData?.user ?? null
 
+  const accountItems = useMemo<SearchCommandItem[]>(
+    () =>
+      user
+        ? [
+            {
+              action: 'account',
+              icon: <Icons.user className='size-4' />,
+              kind: 'account',
+              title: 'Account',
+            },
+            {
+              action: 'logout',
+              icon: <Icons.logOut className='size-4' />,
+              kind: 'account',
+              title: 'Log Out',
+            },
+          ]
+        : [
+            {
+              action: 'signin',
+              icon: <Icons.logIn className='size-4' />,
+              kind: 'account',
+              title: 'Sign In',
+            },
+          ],
+    [user]
+  )
+
   const isEmpty = !search.trim()
 
-  const allGroups = useMemo(() => buildCommandGroups(search), [search])
+  const allGroups = useMemo(
+    () => buildCommandGroups(search, accountItems),
+    [accountItems, search]
+  )
   const groups = isEmpty
     ? allGroups.filter((g) => g.position !== 'after')
     : allGroups
@@ -144,7 +176,31 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
     }
   }
 
+  const handleAccountAction = async (action: SearchCommandItem['action']) => {
+    playConfirm()
+    close()
+
+    if (action === 'account') {
+      navigateToUrl('/account')
+      return
+    }
+
+    if (action === 'signin') {
+      navigateToUrl(getLoginUrl(pathname))
+      return
+    }
+
+    await signOut()
+    router.push('/')
+    router.refresh()
+  }
+
   const handleSelect = (item: (typeof groups)[number]['items'][number]) => {
+    if (item.kind === 'account') {
+      handleAccountAction(item.action)
+      return
+    }
+
     playConfirm()
 
     if (item.kind === 'theme') {
@@ -167,48 +223,6 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
     playConfirm()
     close()
     navigateToUrl(url)
-  }
-
-  const accountItems = user
-    ? [
-        {
-          action: 'account' as const,
-          icon: <Icons.user className='size-4' />,
-          title: 'Account',
-        },
-        {
-          action: 'logout' as const,
-          icon: <Icons.logOut className='size-4' />,
-          title: 'Log Out',
-        },
-      ]
-    : [
-        {
-          action: 'signin' as const,
-          icon: <Icons.logIn className='size-4' />,
-          title: 'Sign In',
-        },
-      ]
-
-  const handleAccountAction = async (
-    action: (typeof accountItems)[number]['action']
-  ) => {
-    playConfirm()
-    close()
-
-    if (action === 'account') {
-      navigateToUrl('/account')
-      return
-    }
-
-    if (action === 'signin') {
-      navigateToUrl(getLoginUrl(pathname))
-      return
-    }
-
-    await signOut()
-    router.push('/')
-    router.refresh()
   }
 
   const renderCommandItem = (item: CommandItemData) => (
@@ -296,24 +310,6 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
               <SearchResultsList groups={tagGroups} onSelect={go} />
             )}
 
-            {accountItems.length > 0 && (
-              <>
-                <CommandGroup heading='Account'>
-                  {accountItems.map((item) => (
-                    <CommandItem
-                      key={item.action}
-                      keywords={['account', 'user', 'logout', 'sign in']}
-                      onSelect={() => handleAccountAction(item.action)}
-                      value={item.title}
-                    >
-                      <span className='text-muted-foreground'>{item.icon}</span>
-                      {item.title}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-                <CommandSeparator />
-              </>
-            )}
           </CommandList>
 
           <CommandMenuFooter />

--- a/src/components/features/search/dialog.tsx
+++ b/src/components/features/search/dialog.tsx
@@ -4,7 +4,7 @@ import { useDocsSearch } from 'fumadocs-core/search/client'
 import type { SharedProps } from 'fumadocs-ui/components/dialog/search'
 import { useI18n } from 'fumadocs-ui/contexts/i18n'
 import { useLenis } from 'lenis/react'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { useTheme } from 'next-themes'
 import { Fragment, useEffect, useMemo, useRef } from 'react'
 import { CommandMenuFooter } from '@/components/features/search/footer'
@@ -32,12 +32,14 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { usePages } from '@/contexts/pages'
+import { getLoginUrl, signOut, useSession } from '@/lib/auth-client'
 import { click, collapse, keyPress, notification } from '@/lib/audio/minimal'
 
 const NAV_SOUND_THROTTLE_MS = 60
 
 export default function SearchDialog({ open, onOpenChange }: SharedProps) {
   const { locale } = useI18n()
+  const pathname = usePathname()
   const router = useRouter()
   const lenis = useLenis()
   const { setTheme, theme } = useTheme()
@@ -57,6 +59,8 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
 
   const { search, setSearch, query } = useDocsSearch({ locale, type: 'fetch' })
   const allPages = usePages()
+  const { data: sessionData } = useSession()
+  const user = sessionData?.user ?? null
 
   const isEmpty = !search.trim()
 
@@ -165,6 +169,36 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
     navigateToUrl(url)
   }
 
+  const accountItems = user
+    ? [
+        { action: 'account' as const, icon: <Icons.user className='size-4' />, title: 'Account' },
+        { action: 'logout' as const, icon: <Icons.logOut className='size-4' />, title: 'Log Out' },
+      ]
+    : [
+        { action: 'signin' as const, icon: <Icons.logIn className='size-4' />, title: 'Sign In' },
+      ]
+
+  const handleAccountAction = async (
+    action: (typeof accountItems)[number]['action']
+  ) => {
+    playConfirm()
+    close()
+
+    if (action === 'account') {
+      navigateToUrl('/account')
+      return
+    }
+
+    if (action === 'signin') {
+      navigateToUrl(getLoginUrl(pathname))
+      return
+    }
+
+    await signOut()
+    router.push('/')
+    router.refresh()
+  }
+
   const renderCommandItem = (item: CommandItemData) => (
     <CommandItem
       data-checked={
@@ -214,6 +248,25 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
             className='supports-timeline-scroll:scroll-fade-effect-y no-scrollbar max-h-[60dvh] min-h-80 scroll-pt-2 scroll-pb-1.5 [--mask-height:32px] [--scroll-buffer:1rem] sm:max-h-80'
             data-lenis-prevent
           >
+            {accountItems.length > 0 && (
+              <>
+                <CommandGroup heading='Account'>
+                  {accountItems.map((item) => (
+                    <CommandItem
+                      key={item.action}
+                      keywords={['account', 'user', 'logout', 'sign in']}
+                      onSelect={() => handleAccountAction(item.action)}
+                      value={item.title}
+                    >
+                      <span className='text-muted-foreground'>{item.icon}</span>
+                      {item.title}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+                <CommandSeparator />
+              </>
+            )}
+
             {groups.map(({ group, items }, i) => (
               <Fragment key={group}>
                 {i > 0 && <CommandSeparator />}

--- a/src/components/features/search/dialog.tsx
+++ b/src/components/features/search/dialog.tsx
@@ -197,7 +197,7 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
 
   const handleSelect = (item: (typeof groups)[number]['items'][number]) => {
     if (item.kind === 'account') {
-      handleAccountAction(item.action)
+      void handleAccountAction(item.action)
       return
     }
 

--- a/src/components/features/search/dialog.tsx
+++ b/src/components/features/search/dialog.tsx
@@ -248,25 +248,6 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
             className='supports-timeline-scroll:scroll-fade-effect-y no-scrollbar max-h-[60dvh] min-h-80 scroll-pt-2 scroll-pb-1.5 [--mask-height:32px] [--scroll-buffer:1rem] sm:max-h-80'
             data-lenis-prevent
           >
-            {accountItems.length > 0 && (
-              <>
-                <CommandGroup heading='Account'>
-                  {accountItems.map((item) => (
-                    <CommandItem
-                      key={item.action}
-                      keywords={['account', 'user', 'logout', 'sign in']}
-                      onSelect={() => handleAccountAction(item.action)}
-                      value={item.title}
-                    >
-                      <span className='text-muted-foreground'>{item.icon}</span>
-                      {item.title}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-                <CommandSeparator />
-              </>
-            )}
-
             {groups.map(({ group, items }, i) => (
               <Fragment key={group}>
                 {i > 0 && <CommandSeparator />}
@@ -302,6 +283,26 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
             {isEmpty ? null : (
               <SearchResultsList groups={tagGroups} onSelect={go} />
             )}
+
+            {accountItems.length > 0 && (
+              <>
+                <CommandGroup heading='Account'>
+                  {accountItems.map((item) => (
+                    <CommandItem
+                      key={item.action}
+                      keywords={['account', 'user', 'logout', 'sign in']}
+                      onSelect={() => handleAccountAction(item.action)}
+                      value={item.title}
+                    >
+                      <span className='text-muted-foreground'>{item.icon}</span>
+                      {item.title}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+                <CommandSeparator />
+              </>
+            )}
+
           </CommandList>
 
           <CommandMenuFooter />

--- a/src/components/features/search/dialog.tsx
+++ b/src/components/features/search/dialog.tsx
@@ -171,11 +171,23 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
 
   const accountItems = user
     ? [
-        { action: 'account' as const, icon: <Icons.user className='size-4' />, title: 'Account' },
-        { action: 'logout' as const, icon: <Icons.logOut className='size-4' />, title: 'Log Out' },
+        {
+          action: 'account' as const,
+          icon: <Icons.user className='size-4' />,
+          title: 'Account',
+        },
+        {
+          action: 'logout' as const,
+          icon: <Icons.logOut className='size-4' />,
+          title: 'Log Out',
+        },
       ]
     : [
-        { action: 'signin' as const, icon: <Icons.logIn className='size-4' />, title: 'Sign In' },
+        {
+          action: 'signin' as const,
+          icon: <Icons.logIn className='size-4' />,
+          title: 'Sign In',
+        },
       ]
 
   const handleAccountAction = async (

--- a/src/components/features/search/dialog.tsx
+++ b/src/components/features/search/dialog.tsx
@@ -195,9 +195,11 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
     router.refresh()
   }
 
-  const handleSelect = (item: (typeof groups)[number]['items'][number]) => {
+  const handleSelect = async (
+    item: (typeof groups)[number]['items'][number]
+  ) => {
     if (item.kind === 'account') {
-      void handleAccountAction(item.action)
+      await handleAccountAction(item.action)
       return
     }
 
@@ -309,7 +311,6 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
             {isEmpty ? null : (
               <SearchResultsList groups={tagGroups} onSelect={go} />
             )}
-
           </CommandList>
 
           <CommandMenuFooter />

--- a/src/components/features/search/dialog.tsx
+++ b/src/components/features/search/dialog.tsx
@@ -32,8 +32,8 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { usePages } from '@/contexts/pages'
-import { getLoginUrl, signOut, useSession } from '@/lib/auth-client'
 import { click, collapse, keyPress, notification } from '@/lib/audio/minimal'
+import { getLoginUrl, signOut, useSession } from '@/lib/auth-client'
 
 const NAV_SOUND_THROTTLE_MS = 60
 
@@ -314,7 +314,6 @@ export default function SearchDialog({ open, onOpenChange }: SharedProps) {
                 <CommandSeparator />
               </>
             )}
-
           </CommandList>
 
           <CommandMenuFooter />

--- a/src/components/features/search/utils/groups.ts
+++ b/src/components/features/search/utils/groups.ts
@@ -95,8 +95,7 @@ export function buildCommandGroups(
   }
 
   const filteredAccountItems = accountItems.filter(
-    (item) =>
-      isEmpty || defaultFilter(item.title, search, item.keywords) > 0
+    (item) => isEmpty || defaultFilter(item.title, search, item.keywords) > 0
   )
 
   return filteredAccountItems.length > 0

--- a/src/components/features/search/utils/groups.ts
+++ b/src/components/features/search/utils/groups.ts
@@ -2,6 +2,7 @@ import { defaultFilter } from 'cmdk'
 import type { SortedResult } from 'fumadocs-core/search'
 import type { PageEntry } from '@/app/actions/pages'
 import { commands } from '@/constants/search'
+import type { CommandItem } from '@/types/search'
 import type { SearchPageGroup, SearchTagGroup } from '@/types/search/results'
 
 function tagFromUrl(url: string): string {
@@ -101,7 +102,11 @@ export function buildCommandGroups(
   return filteredAccountItems.length > 0
     ? [
         ...commandGroups,
-        { group: 'Account', items: filteredAccountItems, position: 'after' as const },
+        {
+          group: 'Account',
+          items: filteredAccountItems,
+          position: 'after' as const,
+        },
       ]
     : commandGroups
 }

--- a/src/components/features/search/utils/groups.ts
+++ b/src/components/features/search/utils/groups.ts
@@ -73,10 +73,12 @@ function bucketPageGroupsByTag(
   return orderTagGroups(tagMap)
 }
 
-export function buildCommandGroups(search: string) {
+export function buildCommandGroups(
+  search: string,
+  accountItems: CommandItem[] = []
+) {
   const isEmpty = !search.trim()
-
-  return commands
+  const commandGroups = commands
     .map(({ group, position, items }) => ({
       group,
       items: items.filter(
@@ -86,6 +88,22 @@ export function buildCommandGroups(search: string) {
       position,
     }))
     .filter(({ items }) => items.length > 0)
+
+  if (accountItems.length === 0) {
+    return commandGroups
+  }
+
+  const filteredAccountItems = accountItems.filter(
+    (item) =>
+      isEmpty || defaultFilter(item.title, search, item.keywords) > 0
+  )
+
+  return filteredAccountItems.length > 0
+    ? [
+        ...commandGroups,
+        { group: 'Account', items: filteredAccountItems, position: 'after' as const },
+      ]
+    : commandGroups
 }
 
 export function buildSearchTagGroups(

--- a/src/components/layout/header/mobile/menu.tsx
+++ b/src/components/layout/header/mobile/menu.tsx
@@ -5,8 +5,8 @@ import { usePathname, useRouter } from 'next/navigation'
 import { Icons } from '@/components/icons/icons'
 import { ThemeToggle } from '@/components/layout/header/theme-toggle'
 import { linkItems, socials } from '@/constants/navigation'
-import { isActive } from '@/lib/is-active'
 import { getLoginUrl, signOut, useSession } from '@/lib/auth-client'
+import { isActive } from '@/lib/is-active'
 import { cn } from '@/lib/utils'
 
 export function MenuPanel({
@@ -117,7 +117,7 @@ export function MenuPanel({
         {user ? (
           <>
             <Link
-              className='flex min-w-0 items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground'
+              className='flex min-w-0 items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground'
               href='/account'
               onClick={() => setTimeout(onClose, 0)}
             >
@@ -127,7 +127,7 @@ export function MenuPanel({
               </span>
             </Link>
             <button
-              className='flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground'
+              className='flex items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground'
               onClick={async () => {
                 await signOut()
                 onClose()
@@ -142,7 +142,7 @@ export function MenuPanel({
           </>
         ) : (
           <Link
-            className='flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground'
+            className='flex items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground'
             href={getLoginUrl(pathname)}
             onClick={() => setTimeout(onClose, 0)}
           >

--- a/src/components/layout/header/mobile/menu.tsx
+++ b/src/components/layout/header/mobile/menu.tsx
@@ -122,7 +122,9 @@ export function MenuPanel({
               onClick={() => setTimeout(onClose, 0)}
             >
               <Icons.user className='size-3.5 shrink-0' />
-              <span className='truncate'>{user.name || user.email || 'Account'}</span>
+              <span className='truncate'>
+                {user.name || user.email || 'Account'}
+              </span>
             </Link>
             <button
               className='flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground'

--- a/src/components/layout/header/mobile/menu.tsx
+++ b/src/components/layout/header/mobile/menu.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { Icons } from '@/components/icons/icons'
 import { ThemeToggle } from '@/components/layout/header/theme-toggle'
 import { linkItems, socials } from '@/constants/navigation'
 import { isActive } from '@/lib/is-active'
+import { getLoginUrl, signOut, useSession } from '@/lib/auth-client'
 import { cn } from '@/lib/utils'
 
 export function MenuPanel({
@@ -20,6 +21,9 @@ export function MenuPanel({
   onClose: () => void
 }) {
   const pathname = usePathname()
+  const router = useRouter()
+  const { data: sessionData } = useSession()
+  const user = sessionData?.user ?? null
   const menuItems = [
     {
       active: 'url' as const,
@@ -108,6 +112,42 @@ export function MenuPanel({
           </button>
           <ThemeToggle />
         </div>
+      </div>
+      <div className='flex items-center justify-between border-t border-dashed px-3 py-2'>
+        {user ? (
+          <>
+            <Link
+              className='flex min-w-0 items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground'
+              href='/account'
+              onClick={() => setTimeout(onClose, 0)}
+            >
+              <Icons.user className='size-3.5 shrink-0' />
+              <span className='truncate'>{user.name || user.email || 'Account'}</span>
+            </Link>
+            <button
+              className='flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground'
+              onClick={async () => {
+                await signOut()
+                onClose()
+                router.push('/')
+                router.refresh()
+              }}
+              type='button'
+            >
+              <Icons.logOut className='size-3.5' />
+              Log Out
+            </button>
+          </>
+        ) : (
+          <Link
+            className='flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground'
+            href={getLoginUrl(pathname)}
+            onClick={() => setTimeout(onClose, 0)}
+          >
+            <Icons.logIn className='size-3.5' />
+            Sign In
+          </Link>
+        )}
       </div>
     </div>
   )

--- a/src/types/search/index.ts
+++ b/src/types/search/index.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 
 export type CommandKind = 'command' | 'page' | 'link'
+export type AccountAction = 'account' | 'logout' | 'signin'
 
 interface BaseItem {
   icon?: ReactNode
@@ -12,6 +13,7 @@ export type CommandItem =
   | (BaseItem & { kind: 'page'; url: string })
   | (BaseItem & { kind: 'link'; url: string })
   | (BaseItem & { kind: 'theme'; theme: 'light' | 'dark' | 'system' })
+  | (BaseItem & { action: AccountAction; kind: 'account' })
 
 export interface CommandGroup {
   group: string


### PR DESCRIPTION
## Summary
- add auth-aware Account / Log Out actions to the command palette
- add Account / Log Out or Sign In actions to the mobile navigation menu
- reuse the existing Better Auth client and logout redirect behavior

## Verification
- reviewed the updated command palette and mobile menu source on the feature branch
- local build was not run because the repository is not checked out in the workspace